### PR TITLE
the executable is not there. I know that the newer versions of these …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ flake8:
 
 pytest:
 	make touch
-	pytest .
+	python3 -m pytest .
 
 coverage:
 	python3 -m pip install pytest pytest_cov


### PR DESCRIPTION
…libraries are not installing executables, requiring that you run the module manually.