### PR TITLE
remove dependency on twistd executable

### DIFF
--- a/.github/workflows/continuous-integration-pip.yml
+++ b/.github/workflows/continuous-integration-pip.yml
@@ -93,8 +93,6 @@ jobs:
           make create_localdb
           make coverage
           make remove_localdb
-          make dump-local-mail
-          make kill-local-mail
 
       - name: Upload to codecov.io
         if: startsWith(matrix.os, 'ubuntu')

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ cython_debug/
 .DS_Store
 *.ini
 *.pid
+localmail.mbox

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ kill-local-mail:
 
 launch-local-mail:
 	make kill-local-mail
-	twistd localmail --imap 10001 --smtp 10002 --http 10003 --file $(LOCALMAIL_MBOX)
+	$(PYTHON) -m twisted localmail --imap 10001 --smtp 10002 --http 10003 --file $(LOCALMAIL_MBOX) & echo "$$!" > $(LOCALMAIL_PID)
 
 dump-local-mail:
 	if [ -r $(LOCALMAIL_MBOX) ]; then echo == BEGIN EMAIL TRANSCRIPT == ; cat $(LOCALMAIL_MBOX) ; echo == END EMAIL TRANSCRIPT == ; fi

--- a/Makefile
+++ b/Makefile
@@ -28,17 +28,14 @@ flake8:
 	flake8 $(PYLINT_FILES)
 
 pytest:
-	make launch-local-mail
 	make touch
 	$(PYTHON) -m pytest . -v --log-cli-level=INFO
 
 pytest-debug:
-	make launch-local-mail
 	make touch
 	$(PYTHON) -m pytest . -v --log-cli-level=DEBUG
 
 pytest-quiet:
-	make launch-local-mail
 	make touch
 	$(PYTHON) -m pytest . --log-cli-level=ERROR
 
@@ -51,7 +48,6 @@ remove_localdb:
 	/bin/rm -f etc/actions_test.ini
 
 coverage:
-	make launch-local-mail
 	$(PYTHON) -m pip install pytest pytest_cov
 	$(PYTHON) -m pytest -v --cov=. --cov-report=xml tests
 
@@ -61,21 +57,6 @@ debug:
 clean:
 	find . -name '*~' -exec rm {} \;
 
-################################################################
-## Local mail server
-
-LOCALMAIL_PID=twistd.pid
-LOCALMAIL_MBOX=/tmp/localmail.mbox
-kill-local-mail:
-	if [ -r $(LOCALMAIL_PID) ]; then echo kill -9 `cat $(LOCALMAIL_PID)` ; kill -9 `cat $(LOCALMAIL_PID)` ; /bin/rm -f $(LOCALMAIL_PID) ; fi
-	/bin/rm -f $(LOCALMAIL_MBOX)
-
-launch-local-mail:
-	make kill-local-mail
-	$(PYTHON) -m twisted localmail --imap 10001 --smtp 10002 --http 10003 --file $(LOCALMAIL_MBOX) & echo "$$!" > $(LOCALMAIL_PID)
-
-dump-local-mail:
-	if [ -r $(LOCALMAIL_MBOX) ]; then echo == BEGIN EMAIL TRANSCRIPT == ; cat $(LOCALMAIL_MBOX) ; echo == END EMAIL TRANSCRIPT == ; fi
 
 ################################################################
 # Installations are used by the CI pipeline:

--- a/db.py
+++ b/db.py
@@ -251,7 +251,7 @@ def delete_user(email):
 
 @log
 def register_email(*, email, name, course_key=None, course_id=None):
-    """Register email for a given course
+    """Register email for a given course. Does not send the links.
     :param: email - user email
     :param: course_key - the key
     :return: dictionary of {'user_id':user_id} for user who is registered.
@@ -271,7 +271,9 @@ def register_email(*, email, name, course_key=None, course_id=None):
         course_id = res[0][0]
 
     user_id =  dbfile.DBMySQL.csfr(get_dbwriter(),
-                               """INSERT INTO users (email, primary_course_id, name) VALUES (%s, %s, %s) ON DUPLICATE KEY UPDATE email=%s""",
+                               """INSERT INTO users (email, primary_course_id, name)
+                               VALUES (%s, %s, %s)
+                               ON DUPLICATE KEY UPDATE email=%s""",
                                (email, course_id, name, email))
     return {'user_id':user_id,'course_id':course_id}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Twisted
 Pillow
 WebTest
 boddle
@@ -14,6 +15,7 @@ pymysql
 pytest
 pytest-cov
 pytest-env
+pytest-html>=4.0.2
 requests
 validate_email_address
 aiosmtplib

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,2 @@
 twistd.pid
+localmail.mbox

--- a/tests/fixtures/localmail_config.py
+++ b/tests/fixtures/localmail_config.py
@@ -1,0 +1,81 @@
+import localmail
+import pytest
+import configparser
+from os.path import join,dirname,abspath
+import logging
+import threading
+import time
+
+LOCALMAIL_CONFIG_FNAME = join( dirname(dirname(abspath(__file__))), "localmail_config.ini")
+
+def singleton(cls):
+    instances = {}
+    def getinstance():
+        if cls not in instances:
+            instances[cls] = cls()
+        return instances[cls]
+    return getinstance
+
+# We use the mail_mutex to block the main thrad until the server is running
+MAIL_TIMEOUT = 10
+mutex = threading.Lock()
+
+def report(smtp, imap, http):
+    """do stuff with ports"""
+    logging.info("smtp=%s",smtp)
+    logging.info("imap=%s",smtp)
+    logging.info("http=%s",smtp)
+    mutex.release()
+    logging.info("*************** LOCALMAIL RUNNING; MUTEX RELEASED *************")
+
+@singleton
+class Localmail():
+    """Create a localmail server and return an object that has the config.
+       We can't shut it down because reactor is not restartable.
+    Over time, we'll implement functionality to search the mailbox.
+    """
+    def __init__(self):
+        localmail_config = configparser.ConfigParser()
+        localmail_config.read( LOCALMAIL_CONFIG_FNAME )
+        if 'smtp' not in localmail_config:
+            logging.error('LOCALMAIL FNAME: %s',FNAME)
+            logging.error('LOCALMMAIL config: %s',localmail_config)
+            logging.error('LOCALMAIL file: %s',open(FNAME).read())
+
+        smtp_port = int(localmail_config['smtp']['smtp_port'])
+        imap_port = int(localmail_config['imap']['imap_port'])
+        http_port = int(localmail_config['localmail']['http_port'])
+        logging.info("smtp_port=%s imap_port=%s http_port=%s",smtp_port,imap_port,http_port)
+
+        mutex.acquire()
+        thread = threading.Thread(
+            target=localmail.run,
+            args=( smtp_port,
+                   imap_port,
+                   http_port,
+                   localmail_config['localmail']['mailbox'], report),
+            daemon=True)
+        thread.start()
+        mutex.acquire(timeout=MAIL_TIMEOUT)
+
+        logging.info("*************** LAUNCHED LOCALMAIL *************")
+        self.localmail_config = localmail_config
+
+    def dump_mailbox(self):
+        logging.info("== BEGIN MAIL TRANSCRIPT ==")
+        with open( self.localmail_config['localmail']['mailbox'],"r") as f:
+            for line in f:
+                logging.info(line.strip())
+        logging.info("== END MAIL TRANSCRIPT ==")
+
+    def clear_mailbox(self):
+        with open( self.localmail_config['localmail']['mailbox'],"w") as f:
+            print(f.truncate())
+
+@pytest.fixture
+def localmail_config():
+
+    lm = Localmail()
+    yield lm.localmail_config
+    lm.dump_mailbox()
+    lm.clear_mailbox()

--- a/tests/fixtures/localmail_config.py
+++ b/tests/fixtures/localmail_config.py
@@ -16,7 +16,7 @@ def singleton(cls):
         return instances[cls]
     return getinstance
 
-# We use the mail_mutex to block the main thrad until the server is running
+# We use the mail_mutex to block the main thread until the server is running
 MAIL_TIMEOUT = 10
 mutex = threading.Lock()
 

--- a/tests/localmail_config.ini
+++ b/tests/localmail_config.ini
@@ -12,3 +12,7 @@ imap_port=10001
 imap_username=user
 imap_password=password
 imap_no_ssl=1
+
+[localmail]
+http_port=8880
+mailbox=localmail.mbox

--- a/tests/mailer_test.py
+++ b/tests/mailer_test.py
@@ -1,16 +1,27 @@
+"""
+Tests that require a working mail server.
+Local mail server provided with a localmail server, which we create in the fixture.
+
+"""
+
+
 from jinja2.nativetypes import NativeEnvironment
 import time
-import mailer
 import sys
 import os
 import uuid
 import logging
 import pytest
 import configparser
+import threading
 
 from os.path import abspath, dirname, join
 
+from fixtures.localmail_config import localmail_config
+
 sys.path.append(dirname(dirname(abspath(__file__))))
+
+import mailer
 
 MSG = """to: {{ to_addrs }}
 from: {{ from_addr }}
@@ -21,26 +32,9 @@ This is a test message.
 
 guid = str(uuid.uuid4())
 
-# https://realpython.com/python-sleep/#adding-a-python-sleep-call-with-decorators
 
-# SKIP_IF = ('GITHUB_JOB' in os.environ) or ('SKIP_MAILER_TEST' in os.environ)
-SKIP_IF = False
-
-USE_LOCALMAIL = True
-
-if USE_LOCALMAIL:
-    localmail_config = configparser.ConfigParser()
-    FNAME = join(dirname(__file__),"localmail_config.ini")
-    localmail_config.read( FNAME )
-    if 'smtp' not in localmail_config:
-        logging.error('LOCALMAIL FNAME: %s',FNAME)
-        logging.error('LOCALMMAIL config: %s',localmail_config)
-        logging.error('LOCALMAIL file: %s',open(FNAME).read())
-
-
-@pytest.mark.skipif(SKIP_IF, reason="does not run on GitHub - outbound SMTP is blocked")
-def test_send_message():
-    TEST_USER_EMAIL = os.environ['TEST_USER_EMAIL']
+def test_send_message(localmail_config):
+    TEST_USER_EMAIL    = os.environ['TEST_USER_EMAIL']
     DO_NOT_REPLY_EMAIL = 'do-not-reply@planttracer.com'
 
     TO_ADDRS = [TEST_USER_EMAIL]
@@ -50,11 +44,7 @@ def test_send_message():
                          guid=guid)
 
     DRY_RUN = False
-    if USE_LOCALMAIL:
-        smtp_config = localmail_config['smtp']
-    else:
-        smtp_config = mailer.smtp_config_from_environ()
-        smtp_config['SMTP_DEBUG'] = 'YES'
+    smtp_config = localmail_config['smtp']
     mailer.send_message(from_addr=DO_NOT_REPLY_EMAIL,
                         to_addrs=TO_ADDRS,
                         smtp_config=smtp_config,
@@ -68,10 +58,7 @@ def test_send_message():
         if guid in M['subject']:
             return mailer.DELETE
 
-    if USE_LOCALMAIL:
-        imap_config = localmail_config['imap']
-    else:
-        imap_config = mailer.imap_config_from_environ()
+    imap_config = localmail_config['imap']
     for i in range(50):
         deleted = mailer.imap_inbox_scan(imap_config, cb)
         if deleted > 0:
@@ -81,28 +68,3 @@ def test_send_message():
         time.sleep(0.1)
     if deleted == 0:
         raise RuntimeError("Could not delete test message")
-
-
-if __name__ == "__main__":
-    # Test program for listing, deleting a message by number, or deleting all messages in imap box
-    import argparse
-    parser = argparse.ArgumentParser(description='IMAP cli',
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--list', action='store_true')
-    parser.add_argument('--delete_all', action='store_true')
-    args = parser.parse_args()
-
-    def m_lister(num, M):
-        print(num, M['subject'])
-
-    def m_delete_all(num, M):
-        print("will delete", num, M['subject'])
-        return mailer.DELETE
-
-    if args.list:
-        func = m_lister
-    elif args.delete_all:
-        func = m_delete_all
-    else:
-        raise RuntimeError("specify an action")
-    mailer.imap_inbox_scan(mailer.imap_config_from_environ(), func)

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -13,10 +13,10 @@ import base64
 import time
 import bottle
 import copy
-
 from os.path import abspath, dirname
 
 sys.path.append(dirname(dirname(abspath(__file__))))
+
 
 import db
 import bottle_app
@@ -103,7 +103,6 @@ def new_user(new_course):
 def api_key(new_user):
     """Simple fixture that just returns a valid api_key"""
     yield new_user[API_KEY]
-
 
 @pytest.fixture
 def new_movie(new_user):


### PR DESCRIPTION
twistd executable no longer appears in more recent python distributions becuase of the goal of removing stand-alone executable. This patch now launches the twistd mail server from the Makefile using python -m and explicitly captures the PID.