### PR TITLE
fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,8 +153,8 @@ run-local:
 	PLANTTRACER_CREDENTIALS=etc/credentials.ini $(PY) bottle_app.py --storelocal
 
 run-local-demo:
-    @echo run bottle locally in demo mode, using local database
-    PLANTTRACER_CREDENTIALS=etc/credentials.ini PLANTTRACER_DEMO_MODE_AVAILABLE=1 $(PY) bottle_app.py --storelocal
+	@echo run bottle locally in demo mode, using local database
+	PLANTTRACER_CREDENTIALS=etc/credentials.ini PLANTTRACER_DEMO_MODE_AVAILABLE=1 $(PY) bottle_app.py --storelocal
 
 debug:
 	make debug-local


### PR DESCRIPTION
Looks like @sbarber2's PR had four spaces instead of a tab character.

Are you using emacs? You should have tabs set at 8, always, and Makefiles get tabs but all other files get just spaces.

<img width="1003" alt="image" src="https://github.com/user-attachments/assets/7498d0d5-7a08-44cf-a724-cb9fcee0db3f">
