### PR TITLE
dbmaint --add_admin --remove_admin PR

### DIFF
--- a/bottle_app.py
+++ b/bottle_app.py
@@ -179,7 +179,7 @@ def page_dict(title='', *, require_auth=False, lookup=True, logout=False,debug=F
         user_id = user_dict['id']
         user_primary_course_id = user_dict['primary_course_id']
         logged_in = 1
-        primary_course_name = db.lookup_course(course_id=user_primary_course_id)['course_name']
+        primary_course_name = db.lookup_course_by_id(course_id=user_primary_course_id)['course_name']
         admin = 1 if db.check_course_admin(user_id=user_id, course_id=user_primary_course_id) else 0
         # If this is a demo account, the user cannot be an admin (security)
         if user_demo:

--- a/docs/ReleaseHistory.rst
+++ b/docs/ReleaseHistory.rst
@@ -19,10 +19,20 @@ Release History
      - 0.9.3
      - October 8, 2024
      - `Closed Issues <https://github.com/Plant-Tracer/webapp/issues?q=is%3Aissue+is%3Aclosed+milestone%3AOct2024>`_
+   * - Dec2024
+     - 0.9.4
+     - December ??, 2024
+     - `Closed Issues <https://github.com/Plant-Tracer/webapp/issues?q=is%3Aissue+is%3Aclosed+milestone%3ADec2024>`_
+
 
 Release Notes
 -------------
 
+0.9.4 Summary
+*************
+
+    * dbmaint: add --add_admin and --remove_admin commands
+    
 0.9.3 Summary
 *************
 

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -161,7 +161,7 @@ def test_add_remove_admin(new_course):
     assert db.check_course_admin(user_id=user_id, course_id=course_id)
     db.remove_course_admin(email = admin_email, course_id = course['id'])
     assert not db.check_course_admin(user_id=user_id, course_id=course_id)
-    db.delete_user(email=admin_email) 
+    db.delete_user(email=admin_email)
 
 def test_new_user(new_user):
     cfg = copy.copy(new_user)

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -161,8 +161,7 @@ def test_add_remove_admin(new_course):
     assert db.check_course_admin(user_id=user_id, course_id=course_id)
     db.remove_course_admin(email = admin_email, course_id = course['id'])
     assert not db.check_course_admin(user_id=user_id, course_id=course_id)
-    db.delete_user(email=admin_email)
-    
+    db.delete_user(email=admin_email) 
 
 def test_new_user(new_user):
     cfg = copy.copy(new_user)

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -148,6 +148,7 @@ def test_new_user(new_user):
 
     assert 'admin' in ret2
     assert 'courses' in ret3
+    assert ret3['courses'][0]['course_key'] == cfg[COURSE_KEY]
 
 
 def test_get_logs(new_user):


### PR DESCRIPTION
Fixes #578 

Adds the --add_admin and --remove_admin commands to dbmaint.py
Fixes db.lookup_user(get_courses=True) when the user is NOT an admin