### PR TITLE
Updates to fix `require` not being supported in browser

### DIFF
--- a/jstests/computesha.notworking
+++ b/jstests/computesha.notworking
@@ -3,6 +3,10 @@
  */
 
 
+//ESM Support in Jest is experimental, which means this test can either pass, 
+//and we have an error in the console (Uncaught ReferenceError: require is not defined)
+//or we can keep this test inactive until ESM support is stable within Jest. 
+
 const $ = require('jquery');
 global.$ = $;
 

--- a/jstests/computesha.test.js
+++ b/jstests/computesha.test.js
@@ -25,7 +25,6 @@ class MockFile {
 
 // Test suite for computeSHA256
 describe('computeSHA256', () => {
-    
     it('should return the correct SHA-256 hash for a known file', async () => {
         const fileContent = 'Hello, World!';  // Known content
         const expectedHash = 'dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f'; // Precomputed SHA-256 for "Hello, World!"
@@ -44,5 +43,4 @@ describe('computeSHA256', () => {
 
         expect(result).toBe(expectedHash);
     });
-
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "crypto-js": "^4.2.0",
         "jquery": "^3.7.1",
         "jslint": "^0.12.1"
       },
@@ -4101,6 +4102,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css.escape": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "crypto-js": "^4.2.0",
     "jquery": "^3.7.1",
     "jslint": "^0.12.1"
   },

--- a/static/planttracer.js
+++ b/static/planttracer.js
@@ -16,7 +16,7 @@ const UNDELETE_BUTTON='UNDELETE';
 const PLAY_LABEL = 'play';
 const PLAY_TRACKED_LABEL = 'play tracked';
 const UPLOAD_TIMEOUT_SECONDS = 20;
-const CryptoJS = require('crypto-js');
+
 // sounds for buttons
 var SOUNDS = [];
 if (typeof Audio !== 'undefined') {
@@ -108,9 +108,14 @@ function check_upload_metadata()
 //        var sha256 = await computeSHA256(file);
 async function computeSHA256(file) {
     const arrayBuffer = await file.arrayBuffer();
-    const wordArray = CryptoJS.lib.WordArray.create(new Uint8Array(arrayBuffer));
-    const hash = CryptoJS.SHA256(wordArray).toString(CryptoJS.enc.Hex);
-    return hash;
+
+    // Compute the SHA-256 hash
+    const hashBuffer = await crypto.subtle.digest('SHA-256', arrayBuffer);
+
+    // Convert the hash to a hexadecimal string
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+    return hashHex;
 }
 
 /*

--- a/static/planttracer.js
+++ b/static/planttracer.js
@@ -16,8 +16,7 @@ const UNDELETE_BUTTON='UNDELETE';
 const PLAY_LABEL = 'play';
 const PLAY_TRACKED_LABEL = 'play tracked';
 const UPLOAD_TIMEOUT_SECONDS = 20;
-const crypto = require('crypto'); 
-
+const CryptoJS = require('crypto-js');
 // sounds for buttons
 var SOUNDS = [];
 if (typeof Audio !== 'undefined') {
@@ -108,16 +107,10 @@ function check_upload_metadata()
 // You get the results with
 //        var sha256 = await computeSHA256(file);
 async function computeSHA256(file) {
-    // Read the file as an ArrayBuffer
     const arrayBuffer = await file.arrayBuffer();
-
-    // Compute the SHA-256 hash
-    const hashBuffer = await crypto.subtle.digest('SHA-256', arrayBuffer);
-
-    // Convert the hash to a hexadecimal string
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
-    return hashHex;
+    const wordArray = CryptoJS.lib.WordArray.create(new Uint8Array(arrayBuffer));
+    const hash = CryptoJS.SHA256(wordArray).toString(CryptoJS.enc.Hex);
+    return hash;
 }
 
 /*


### PR DESCRIPTION
Fixes #630 by instead using a browser compatible library called crypto-js, includes rewrite for the computeSHA256 async function to reflect the new crypto library