### PR TITLE
Clean up codebase: rules, pylint, Python 3.12, utils.js

### DIFF
--- a/.cursor/CURSOR_DESIGN.md
+++ b/.cursor/CURSOR_DESIGN.md
@@ -76,7 +76,7 @@ Both coverage files are uploaded to codecov.io in CI/CD.
 ### Type Annotations
 
 **Preference**: Use type annotations when possible. The project uses:
-- Python 3.13+ type hints
+- Python 3.12 (matches Ubuntu 24.04; see `pyproject.toml`)
 - Pyright for type checking (configured in `pyproject.toml`)
 - Type checking mode: `basic` (not strict)
 
@@ -136,7 +136,7 @@ These are separate from the main Flask app and have their own deployment pipelin
 2. **Type annotations are preferred** but not strictly required
 3. **JavaScript coverage from Chromium tests is missing** - this needs to be fixed
 4. **Tests should be self-contained** - fixtures handle all setup
-5. **jQuery has been completely eliminated** - replaced with custom lightweight `$` utility in `utils.js`
+5. **jQuery has been completely eliminated** - replaced with custom lightweight `$` and `$$` utilities in `utils.js` (see `.cursor/rules/utils-not-jquery.mdc` for the allowed API)
 6. **Local services run on fixed ports** - see `Makefile` for endpoints
 
 ## Environment Variables

--- a/.cursor/rules/corridor-mcp-server-usage.mdc
+++ b/.cursor/rules/corridor-mcp-server-usage.mdc
@@ -1,0 +1,11 @@
+---
+description: Use Corridor MCP to analyze the plan before generating code
+alwaysApply: true
+---
+
+# Corridor MCP Server Usage
+
+Every time you generate code, use the **analyzePlan** tool from Corridor's MCP Server (corridor) to analyze the plan or thought process.
+
+- **ALWAYS** use Corridor to analyze the plan before generating code.
+- Always generate a plan before generating code.

--- a/.cursor/rules/pylint-before-commit.mdc
+++ b/.cursor/rules/pylint-before-commit.mdc
@@ -1,12 +1,12 @@
 ---
 description: Run pylint before committing; do not commit code that fails pylint
-globs:
+globs: ["**/*.py"]
 alwaysApply: true
 ---
 
 **Do not commit code that fails pylint.**
 
 1. **Before committing:** Run pylint on any modified Python files (e.g. `poetry run pylint src/app/...`) and fix all reported issues.
-2. **Imports:** Put all imports at the **top level** of the file. Do not use imports inside functions (C0415 import-outside-toplevel).
-3. **Return statements:** Keep the number of return statements per function within pylint’s limit (R0911 too-many-return-statements). Refactor with result variables and a single return where needed.
-4. **No lint shortcuts:** Do not leave pylint errors for “later”; resolve them before commit/push.
+2. **Imports:** Put all imports at the **top level** of the file. Do not use imports inside functions (C0415 import-outside-toplevel). **Exception:** Imports inside an `if __name__ == "__main__":` block (e.g. `import argparse`) are allowed, since they run only when the module is executed as a script.
+3. **Return statements:** The project disables R0911 (too-many-return-statements) in `pyproject.toml` where needed; prefer refactoring with result variables and a single return when practical.
+4. **No lint shortcuts:** Do not leave pylint errors for "later"; resolve them before commit/push.

--- a/.cursor/rules/utils-not-jquery.mdc
+++ b/.cursor/rules/utils-not-jquery.mdc
@@ -7,9 +7,7 @@ alwaysApply: true
 
 In this project, **`$` is not jQuery.** It is the custom lightweight helper from `src/app/static/utils.js`. Do not assume jQuery methods exist.
 
-- **Use:** `prop`, `attr`, `val`, `html`, `text`, `show`, `hide`, `on`, `off`, `click`, `css`, `get(index)`, `fadeIn`, `fadeOut`.
-- **Do not use:** `hasClass`, `addClass`, `removeClass`, `toggleClass`, `one()`, `find()`, `parent()`, `children()`, or any other jQuery-specific API unless you have verified it exists in `utils.js`.
+- **Use:** `prop`, `attr`, `val`, `html`, `text`, `show`, `hide`, `on`, `off`, `click`, `css`, `get(index)`, `fadeIn`, `fadeOut`, `$.post`, `$$`. Also available: `hasClass`, `addClass`, `removeClass`, `toggleClass`, `one(event, handler)`, `find(selector)`, `parent()`, `children()` (implemented in `utils.js` on both `DOMWrapper` and `DOMCollection`).
+- **Do not use** any other jQuery or DOM API unless you have verified it exists in `utils.js`.
 
-For class names, use the DOM: `element.classList.contains()`, `element.classList.add()`, `element.classList.remove()`. Get the element with `$('#id').get(0)`.
-
-For one-time event listeners, use native: `element.addEventListener('load', fn, { once: true })` instead of `$.one('load', fn)`.
+To get the raw DOM element from a single-element wrapper: `$('#id').get(0)` or `$('#id').get()`. For one-time event listeners you can use `$('#id').one('load', fn)` or native `element.addEventListener('load', fn, { once: true })`.

--- a/lambda-resize/pyproject.toml
+++ b/lambda-resize/pyproject.toml
@@ -51,7 +51,7 @@ indent = 4
 
 [tool.pylint]
 # Specify the Python version Pylint should assume for syntax checking.
-py-version = "3.13"
+py-version = "3.12"
 ignore-paths = [
     "src/home_app/e11/.*"
 ]
@@ -68,7 +68,8 @@ disable = [
     "line-too-long",
     "unspecified-encoding",
     "too-few-public-methods",
-    "invalid-name"
+    "invalid-name",
+    "too-many-return-statements"
 ]
 
 [tool.pylint.design]
@@ -79,7 +80,7 @@ max-args = 10
 max-public-methods = 20
 
 [tool.pyright]
-pythonVersion = "3.13"
+pythonVersion = "3.12"
 venvPath = "."
 venv = ".venv"
 include = ["src"]

--- a/lambda-resize/src/resize_app/resize.py
+++ b/lambda-resize/src/resize_app/resize.py
@@ -145,7 +145,7 @@ def api_log():
 ################################################################
 ## main entry point from lambda system
 
-# pylint: disable=too-many-return-statements, disable=too-many-branches, disable=unused-argument
+# pylint: disable=too-many-branches, disable=unused-argument
 def lambda_handler(event, context) -> Dict[str, Any]:
     """called by lambda"""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ disable = [
     "fixme",
     "trailing-whitespace",      # AI does this
     "too-many-positional-arguments",
+    "too-many-return-statements",
 ]
 
 [tool.pylint.design]
@@ -106,7 +107,7 @@ max-args = 10
 max-public-methods = 20
 
 [tool.pyright]
-pythonVersion = "3.13"
+pythonVersion = "3.12"
 venvPath = "./"
 venv = ".venv"
 include = ["."]

--- a/src/app/flask_api.py
+++ b/src/app/flask_api.py
@@ -207,7 +207,6 @@ def api_send_link():
         return E.INVALID_MAILER_CONFIGURATION
     return {'error': False, 'message': 'If you have an account, a link was sent. If you do not receive a link within 60 seconds, you may need to <a href="/register">register</a> your email address.'}
 
-#pylint: disable=too-many-return-statements
 @api_bp.route('/bulk-register', methods=POST)
 def api_bulk_register():
     """Allow an admin to register people in the class, increasing the class size as necessary to do so."""

--- a/src/app/flask_app.py
+++ b/src/app/flask_app.py
@@ -3,7 +3,6 @@ Main Flask application for planttracer.
 """
 
 # pylint: disable=too-many-lines
-# pylint: disable=too-many-return-statements
 
 import sys
 import os

--- a/src/app/static/utils.js
+++ b/src/app/static/utils.js
@@ -111,6 +111,67 @@ class DOMCollection {
         return this;
     }
 
+    get(index) {
+        if (index === undefined) {
+            return this.elements[0] || null;
+        }
+        return this.elements[index] || null;
+    }
+
+    hasClass(className) {
+        return this.elements[0] ? this.elements[0].classList.contains(className) : false;
+    }
+
+    addClass(className) {
+        this.elements.forEach(el => {
+            if (el) el.classList.add(className);
+        });
+        return this;
+    }
+
+    removeClass(className) {
+        this.elements.forEach(el => {
+            if (el) el.classList.remove(className);
+        });
+        return this;
+    }
+
+    toggleClass(className) {
+        this.elements.forEach(el => {
+            if (el) el.classList.toggle(className);
+        });
+        return this;
+    }
+
+    one(event, handler) {
+        this.elements.forEach(el => {
+            if (el) el.addEventListener(event, handler, { once: true });
+        });
+        return this;
+    }
+
+    find(selector) {
+        const found = [];
+        this.elements.forEach(el => {
+            if (el) {
+                const matches = el.querySelectorAll(selector);
+                found.push(...matches);
+            }
+        });
+        return new DOMCollection(found);
+    }
+
+    parent() {
+        const parents = this.elements.map(el => el && el.parentElement).filter(Boolean);
+        return new DOMCollection(parents);
+    }
+
+    children() {
+        const childLists = this.elements.map(el => el ? Array.from(el.children) : []);
+        const flat = childLists.flat();
+        return new DOMCollection(flat);
+    }
+
     get length() {
         return this.elements.length;
     }
@@ -296,6 +357,45 @@ class DOMWrapper {
             this.element.style[property] = value;
         }
         return this;
+    }
+
+    hasClass(className) {
+        return this.element ? this.element.classList.contains(className) : false;
+    }
+
+    addClass(className) {
+        if (this.element) this.element.classList.add(className);
+        return this;
+    }
+
+    removeClass(className) {
+        if (this.element) this.element.classList.remove(className);
+        return this;
+    }
+
+    toggleClass(className) {
+        if (this.element) this.element.classList.toggle(className);
+        return this;
+    }
+
+    one(event, handler) {
+        if (this.element) this.element.addEventListener(event, handler, { once: true });
+        return this;
+    }
+
+    find(selector) {
+        if (!this.element) return new DOMCollection([]);
+        return new DOMCollection(this.element.querySelectorAll(selector));
+    }
+
+    parent() {
+        if (!this.element || !this.element.parentElement) return new DOMCollection([]);
+        return new DOMCollection([this.element.parentElement]);
+    }
+
+    children() {
+        if (!this.element) return new DOMCollection([]);
+        return new DOMCollection(this.element.children);
     }
 }
 


### PR DESCRIPTION
- Add Corridor rule to .cursor/rules/corridor-mcp-server-usage.mdc
- Move too-many-return-statements to pyproject.toml (main + lambda-resize); remove inline disables from flask_app, flask_api, resize
- Set Python 3.12 in CURSOR_DESIGN.md and pyright (main + lambda-resize)
- Pylint rule: allow argparse in if __name__; set globs to **/*.py; document R0911 disabled in pyproject.toml
- utils.js: add hasClass, addClass, removeClass, toggleClass, one, find, parent, children, get(index) on DOMCollection; update utils-not-jquery rule
- CURSOR_DESIGN: Python 3.12, reference utils-not-jquery rule

Made-with: Cursor