### PR TITLE
Match webapp look and feel to planttracer.com

### DIFF
--- a/src/app/templates/base.html
+++ b/src/app/templates/base.html
@@ -17,7 +17,7 @@
     <!-- Outfit font (matches planttracer.com) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
 
     <script src="{{ url_for('static', filename='jquery-3.7.1.min.js') }}"></script>
     <script type="module" src="{{ url_for('static', filename='planttracer.js') }}"></script>

--- a/src/app/templates/base.html
+++ b/src/app/templates/base.html
@@ -14,6 +14,11 @@
           integrity="sha384-X38yfunGUhNzHpBaEBsWLO+A0HDYOQi8ufWDkZ0k9e0eXz/tH3II7uKZ9msv++Ls" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/grids-responsive-min.css" >  <!-- possibly remove -->
 
+    <!-- Outfit font (matches planttracer.com) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+
     <script src="{{ url_for('static', filename='jquery-3.7.1.min.js') }}"></script>
     <script type="module" src="{{ url_for('static', filename='planttracer.js') }}"></script>
 
@@ -58,8 +63,36 @@
 
     <style>
       html {
-      margin-left: 20px;
-      margin-right: 20px;
+        margin-left: 20px;
+        margin-right: 20px;
+      }
+      body {
+        font-family: 'Outfit', sans-serif;
+        color: #606061;
+      }
+      .pure-menu.pure-menu-horizontal {
+        background: linear-gradient(to right, rgb(53,181,147), rgb(161,210,68));
+        padding: 0 10px;
+      }
+      .pure-menu-heading.pure-menu-link {
+        color: white !important;
+        font-size: 150%;
+        font-weight: 600;
+        font-family: 'Outfit', sans-serif;
+      }
+      .pure-menu-link {
+        color: white !important;
+        font-family: 'Outfit', sans-serif;
+      }
+      .pure-menu-link:hover,
+      .pure-menu-link:focus {
+        background: transparent !important;
+        color: white !important;
+        text-shadow: 1px 1px 3px #9dff2e;
+      }
+      .pure-menu-item.pure-menu-selected > .pure-menu-link {
+        background: transparent !important;
+        text-shadow: 2px 2px 5px #9dff2e;
       }
     </style>
 

--- a/src/app/templates/base.html
+++ b/src/app/templates/base.html
@@ -79,10 +79,14 @@
         font-size: 150%;
         font-weight: 600;
         font-family: 'Outfit', sans-serif;
+        padding: 20px 1em;
+        text-transform: none;
+        letter-spacing: normal;
       }
       .pure-menu-link {
         color: white !important;
         font-family: 'Outfit', sans-serif;
+        padding: 20px 1em;
       }
       .pure-menu-link:hover,
       .pure-menu-link:focus {
@@ -112,7 +116,7 @@
              doesn't happen when deploying in a AWS Lambda domain followed
              by a prefix such as Prod/ or Test/.
           -->
-        <a href="." class="pure-menu-heading pure-menu-link">PlantTracer</a>
+        <a href="." class="pure-menu-heading pure-menu-link">Plant Tracer</a>
         <ul class="pure-menu-list">
           {% if logged_in %}
           <li class="pure-menu-item">


### PR DESCRIPTION
## Summary

- Adds the **Outfit** Google Font to match the typography used on planttracer.com
- Applies the same **green gradient nav bar** (`rgb(53,181,147)` → `rgb(161,210,68)`) from planttracer.com's `desktopNavBar.css`
- Sets nav links and the "PlantTracer" heading to **white**, with a yellow-green glow on hover/focus (`text-shadow: 1px 1px 3px #9dff2e`)
- Sets body text color to `#606061` (dark gray, matching planttracer.com's `desktopIndex.css`)
- No page elements removed; all PureCSS layout classes and Jinja template logic are unchanged

## Changes

Single file: `src/app/templates/base.html`
- Added Outfit font preconnect + stylesheet link
- Expanded the `<style>` block with nav gradient, white link colors, hover glow, and body typography

## Test plan

- [ ] Start local Flask dev server (`make run-local-debug`) and visually verify the nav bar gradient and white links on any page
- [ ] Check logged-in and logged-out nav states both render correctly
- [ ] Check hover states on nav links show the yellow-green glow
- [ ] Verify no regression in page layout or functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)