### PR TITLE
Users page enhancements: bulk-register names, user list fixes, test isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ Plant Tracer is a Flask-based web application for uploading, managing, and annot
 
 Never commit or push directly to the `main` branch. All changes must go through a feature branch and be merged via Pull Request. Only proceed with a direct commit to `main` if the user explicitly says to override this rule.
 
+Every commit message must reference a GitHub Issue number (e.g. `fixes #123` or `refs #123`). If no Issue exists for the current change, generate a proposed Issue title and description, ask the user to confirm or edit it, and only create the Issue (via `gh issue create`) after receiving approval.
+
 ## Common Commands
 
 ```bash

--- a/jstests/bulk_register_users.test.js
+++ b/jstests/bulk_register_users.test.js
@@ -14,6 +14,7 @@ describe('bulk_register_users_func', () => {
         global.API_BASE = 'http://example.com/'
         global.api_key = 'test_api_key';
         global.user_primary_course_id = 1;
+        global.list_users = jest.fn();
 
       // Add the mock DOM elements the function expects to find
 
@@ -53,6 +54,7 @@ describe('bulk_register_users_func', () => {
             "names": '',
         });
         expect($('#message').html()).toBe('Registered 1 email addresses');
+        expect(global.list_users).toHaveBeenCalledTimes(1);
     });
 
     test('should handle invalid email response', () => {

--- a/jstests/bulk_register_users.test.js
+++ b/jstests/bulk_register_users.test.js
@@ -50,6 +50,7 @@ describe('bulk_register_users_func', () => {
             planttracer_endpoint: window.origin + "",
             course_id: user_primary_course_id,
             "email-addresses": 'test@example.com',
+            "names": '',
         });
         expect($('#message').html()).toBe('Registered 1 email addresses');
     });
@@ -72,8 +73,66 @@ describe('bulk_register_users_func', () => {
             planttracer_endpoint: window.origin + "",
             course_id: user_primary_course_id,
             "email-addresses": 'missingdomain@.com',
+            "names": '',
         });
         expect($('#message').html()).toBe('error: Invalid email address');
+    });
+
+    test('should parse email,name line and send both fields', () => {
+        $.post = jest.fn().mockImplementation((_url, _payload) => ({
+            done: jest.fn().mockReturnThis(),
+            fail: jest.fn().mockReturnThis(),
+        }));
+
+        $('#br_email_addresses').val('alice@example.com,Alice Smith');
+
+        bulk_register_users_func();
+
+        expect($.post).toHaveBeenCalledWith(`${API_BASE}api/bulk-register`, {
+            api_key,
+            planttracer_endpoint: window.origin + "",
+            course_id: user_primary_course_id,
+            "email-addresses": 'alice@example.com',
+            "names": 'Alice Smith',
+        });
+    });
+
+    test('should parse multiple lines with mixed name presence', () => {
+        $.post = jest.fn().mockImplementation((_url, _payload) => ({
+            done: jest.fn().mockReturnThis(),
+            fail: jest.fn().mockReturnThis(),
+        }));
+
+        $('#br_email_addresses').val('alice@example.com, Alice Smith\nbob@example.com\ncharlie@example.com, Charlie Darwin');
+
+        bulk_register_users_func();
+
+        expect($.post).toHaveBeenCalledWith(`${API_BASE}api/bulk-register`, {
+            api_key,
+            planttracer_endpoint: window.origin + "",
+            course_id: user_primary_course_id,
+            "email-addresses": 'alice@example.com\nbob@example.com\ncharlie@example.com',
+            "names": 'Alice Smith\n\nCharlie Darwin',
+        });
+    });
+
+    test('should skip blank lines when parsing input', () => {
+        $.post = jest.fn().mockImplementation((_url, _payload) => ({
+            done: jest.fn().mockReturnThis(),
+            fail: jest.fn().mockReturnThis(),
+        }));
+
+        $('#br_email_addresses').val('alice@example.com\n\nbob@example.com');
+
+        bulk_register_users_func();
+
+        expect($.post).toHaveBeenCalledWith(`${API_BASE}api/bulk-register`, {
+            api_key,
+            planttracer_endpoint: window.origin + "",
+            course_id: user_primary_course_id,
+            "email-addresses": 'alice@example.com\nbob@example.com',
+            "names": '\n',
+        });
     });
 
 });

--- a/jstests/list_users_data.test.js
+++ b/jstests/list_users_data.test.js
@@ -24,6 +24,7 @@ beforeAll(() => {
 describe('list_users_data', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    global.user_primary_course_id = 1;
     document.body.innerHTML = '<div id="your-users"></div>';
   });
 
@@ -92,5 +93,47 @@ describe('list_users_data', () => {
 
     const html = document.getElementById('your-users').innerHTML;
     expect(html).not.toContain('Click here to invite a user');
+  });
+
+  test('should label primary course as "Primary course" and others as "Course"', () => {
+    const course_array = {
+      1: { course_id: 1, course_name: 'Primary Course' },
+      2: { course_id: 2, course_name: 'Other Course' },
+    };
+    global.user_primary_course_id = 1;
+    const users = [
+      { user_id: 10, user_name: 'Alice', email: 'alice@example.com', primary_course_id: 1, first: null, last: null },
+      { user_id: 20, user_name: 'Bob',   email: 'bob@example.com',   primary_course_id: 2, first: null, last: null },
+    ];
+
+    list_users_data(users, course_array);
+
+    const html = document.getElementById('your-users').innerHTML;
+    expect(html).toContain('Primary course: Primary Course');
+    expect(html).toContain('Course: Other Course');
+    expect(html).not.toContain('Primary course: Other Course');
+  });
+
+  test('should not duplicate course sections when users are sorted by primary_course_id', () => {
+    const course_array = {
+      1: { course_id: 1, course_name: 'Course One' },
+      2: { course_id: 2, course_name: 'Course Two' },
+    };
+    global.user_primary_course_id = 1;
+    // Users already sorted by primary_course_id (as the backend now guarantees)
+    const users = [
+      { user_id: 10, user_name: 'Alice', email: 'alice@example.com', primary_course_id: 1, first: null, last: null },
+      { user_id: 20, user_name: 'Bob',   email: 'bob@example.com',   primary_course_id: 2, first: null, last: null },
+      { user_id: 30, user_name: 'Carol', email: 'carol@example.com', primary_course_id: 2, first: null, last: null },
+    ];
+
+    list_users_data(users, course_array);
+
+    const html = document.getElementById('your-users').innerHTML;
+    // Each course heading should appear exactly once
+    const matches1 = (html.match(/Course One/g) || []).length;
+    const matches2 = (html.match(/Course Two/g) || []).length;
+    expect(matches1).toBe(1);
+    expect(matches2).toBe(1);
   });
 });

--- a/jstests/list_users_data.test.js
+++ b/jstests/list_users_data.test.js
@@ -43,7 +43,7 @@ describe('list_users_data', () => {
     list_users_data(users, course_array);
 
     const html = document.getElementById('your-users').innerHTML;
-    expect(html).toContain(`<td>${userData.user1.name} (${userData.user1.user_id}) </td><td>${userData.user1.email}</td>`);
+    expect(html).toContain(`<td>${userData.user1.name}</td><td>${userData.user1.email}</td><td>${userData.user1.user_id}</td>`);
   });
 
   test('should correctly classify and display inactive users', () => {
@@ -70,8 +70,8 @@ describe('list_users_data', () => {
     list_users_data(users, course_array);
 
     const html = document.getElementById('your-users').innerHTML;
-    expect(html).toContain(`<td>${userData.user1.name} (${userData.user1.user_id}) </td><td>${userData.user1.email}</td>`);
-    expect(html).toContain(`<td>${userData.user2.name} (${userData.user2.user_id}) </td><td>${userData.user2.email}</td>`);
+    expect(html).toContain(`<td>${userData.user1.name}</td><td>${userData.user1.email}</td><td>${userData.user1.user_id}</td>`);
+    expect(html).toContain(`<td>${userData.user2.name}</td><td>${userData.user2.email}</td><td>${userData.user2.user_id}</td>`);
   });
 
   test('should display a link to invite users for admins', () => {

--- a/src/app/flask_api.py
+++ b/src/app/flask_api.py
@@ -231,14 +231,17 @@ def api_bulk_register():
 
     planttracer_endpoint = request.values.get('planttracer_endpoint') # for emails
     email_addresses      = request.values.get('email-addresses').replace(","," ").replace(";"," ").replace(" ","\n").split("\n")
+    names_raw            = request.values.get('names', '')
+    names                = [n.strip() for n in names_raw.split('\n')] if names_raw.strip() else []
     user_ids             = []
     email_error          = None
     try:
-        for email in email_addresses:
+        for idx, email in enumerate(email_addresses):
             email = email.strip()
             if not validate_email(email, check_mx=C.CHECK_MX):
                 return E.INVALID_EMAIL
-            user = odb.register_email(email=email, course_id=course_id, user_name="")
+            user_name = names[idx] if idx < len(names) else ""
+            user = odb.register_email(email=email, course_id=course_id, user_name=user_name)
             user_id = user[USER_ID]
             new_api_key = odb.make_new_api_key_for_user_id(user_id=user_id)
             user_ids.append(user_id)

--- a/src/app/odb.py
+++ b/src/app/odb.py
@@ -953,6 +953,9 @@ def list_users_courses(*, user_id):
             course_ids.add(u[PRIMARY_COURSE_ID])
     courses_list = [c for c in (ddbo.get_course(cid) for cid in course_ids) if c]
 
+    # Sort by primary_course_id so the JS grouping logic produces one section per course
+    users_list.sort(key=lambda u: u.get(PRIMARY_COURSE_ID, ''))
+
     return {USERS: users_list, COURSES: courses_list}
 
 

--- a/src/app/odb.py
+++ b/src/app/odb.py
@@ -891,13 +891,36 @@ def list_users_courses(*, user_id):
     'courses' - all of the courses to which the user has access, and all the people in them.
     :param: user_id - the user doing the listing (determines what they can see)
 
-    NOTE: With MySQL users could only see the course list if they were admins.
-    With DynamoDB, users can see the full course list for all of their courses.
+    Admins see every user enrolled in each of their admin courses.
+    Non-admins see only themselves.
     """
     ddbo = DDBO()
     user = ddbo.get_user(user_id)
-    return {USERS: [user],
-            COURSES :  [ddbo.get_course(course_id) for course_id in user[ COURSES ] ] }
+    admin_for_courses = user.get(ADMIN_FOR_COURSES, [])
+
+    if not admin_for_courses:
+        return {USERS: [user],
+                COURSES: [ddbo.get_course(course_id) for course_id in user.get(COURSES, [])]}
+
+    # Collect all users enrolled in any course this user admins (deduplicated)
+    seen_user_ids = set()
+    users_list = []
+    for course_id in admin_for_courses:
+        for enrolled_user_id in course_enrollments(course_id):
+            if enrolled_user_id not in seen_user_ids:
+                seen_user_ids.add(enrolled_user_id)
+                enrolled_user = ddbo.get_user(enrolled_user_id)
+                if enrolled_user:
+                    users_list.append(enrolled_user)
+
+    # Include all admin courses plus any primary courses referenced by the returned users
+    course_ids = set(admin_for_courses)
+    for u in users_list:
+        if u.get(PRIMARY_COURSE_ID):
+            course_ids.add(u[PRIMARY_COURSE_ID])
+    courses_list = [c for c in (ddbo.get_course(cid) for cid in course_ids) if c]
+
+    return {USERS: users_list, COURSES: courses_list}
 
 
 def list_admins():

--- a/src/app/odb.py
+++ b/src/app/odb.py
@@ -370,6 +370,33 @@ class DDBO:
         items = response.get('Items', [])
         return items[0][API_KEY] if items else None
 
+    def get_user_login_times(self, user_id):
+        """Return (first_used_at, last_used_at) for a user by aggregating across all their api_keys.
+        Returns (None, None) if the user has no api_keys or none have been used yet."""
+        last_evaluated_key = None
+        first_used = None
+        last_used = None
+        while True:
+            kwargs = {
+                'IndexName': 'user_id_idx',
+                'KeyConditionExpression': Key(USER_ID).eq(user_id),
+                'ProjectionExpression': 'first_used_at, last_used_at',
+            }
+            if last_evaluated_key:
+                kwargs['ExclusiveStartKey'] = last_evaluated_key
+            response = self.api_keys.query(**kwargs)
+            for item in response.get('Items', []):
+                f = item.get('first_used_at')
+                l = item.get('last_used_at')
+                if f is not None:
+                    first_used = f if first_used is None else min(first_used, f)
+                if l is not None:
+                    last_used = l if last_used is None else max(last_used, l)
+            last_evaluated_key = response.get('LastEvaluatedKey')
+            if not last_evaluated_key:
+                break
+        return first_used, last_used
+
     def del_api_key(self, api_key):
         self.api_keys.delete_item(Key = { API_KEY :api_key},
                                   ConditionExpression = 'attribute_exists(api_key)' )
@@ -899,6 +926,9 @@ def list_users_courses(*, user_id):
     admin_for_courses = user.get(ADMIN_FOR_COURSES, [])
 
     if not admin_for_courses:
+        first, last = ddbo.get_user_login_times(user_id)
+        user['first'] = first
+        user['last'] = last
         return {USERS: [user],
                 COURSES: [ddbo.get_course(course_id) for course_id in user.get(COURSES, [])]}
 
@@ -911,6 +941,9 @@ def list_users_courses(*, user_id):
                 seen_user_ids.add(enrolled_user_id)
                 enrolled_user = ddbo.get_user(enrolled_user_id)
                 if enrolled_user:
+                    first, last = ddbo.get_user_login_times(enrolled_user_id)
+                    enrolled_user['first'] = first
+                    enrolled_user['last'] = last
                     users_list.append(enrolled_user)
 
     # Include all admin courses plus any primary courses referenced by the returned users

--- a/src/app/odb.py
+++ b/src/app/odb.py
@@ -939,12 +939,16 @@ def list_users_courses(*, user_id):
         for enrolled_user_id in course_enrollments(course_id):
             if enrolled_user_id not in seen_user_ids:
                 seen_user_ids.add(enrolled_user_id)
-                enrolled_user = ddbo.get_user(enrolled_user_id)
-                if enrolled_user:
-                    first, last = ddbo.get_user_login_times(enrolled_user_id)
-                    enrolled_user['first'] = first
-                    enrolled_user['last'] = last
-                    users_list.append(enrolled_user)
+                try:
+                    enrolled_user = ddbo.get_user(enrolled_user_id)
+                except InvalidUser_Id:
+                    logger.warning("course_enrollments returned unknown user_id %s for course %s — skipping",
+                                   enrolled_user_id, course_id)
+                    continue
+                first, last = ddbo.get_user_login_times(enrolled_user_id)
+                enrolled_user['first'] = first
+                enrolled_user['last'] = last
+                users_list.append(enrolled_user)
 
     # Include all admin courses plus any primary courses referenced by the returned users
     course_ids = set(admin_for_courses)

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -863,15 +863,17 @@ function list_ready_function() {
 function list_users_data( users, course_array ) {
   let current_course = null;
   let div = $('#your-users');
-  let h = '<table>';
-  h += '<tbody>';
+  let h = '';
   function user_html(user) {
     let d1 = user.first ? new Date(user.first * 1000).toString() : "n/a";
     let d2 = user.last ? new Date(user.last  * 1000).toString() : "n/a";
     let ret = '';
     if (current_course != user.primary_course_id) {
-      ret += `<tr><td colspan='4'>&nbsp;</td></tr>\n`;
-      ret += `<tr><th colspan='4'>Primary course: ${course_array[user.primary_course_id].course_name} (${user.primary_course_id})</th></tr>\n`;
+      if (current_course !== null) {
+        ret += '</tbody></table>\n';
+      }
+      ret += `<p><b>Primary course: ${course_array[user.primary_course_id].course_name} (${user.primary_course_id})</b></p>\n`;
+      ret += '<table><tbody>\n';
       ret += '<tr><th>Name</th><th>Email</th><th>ID</th><th>First Seen</th><th>Last Seen</th></tr>\n';
       current_course = user.primary_course_id;
     }
@@ -879,7 +881,11 @@ function list_users_data( users, course_array ) {
     return ret;
   }
   users.forEach( user => ( h+= user_html(user) ));
-  h += '</tbody></table>';
+  if (current_course !== null) {
+    h += '</tbody></table>';
+  } else {
+    h += '<table><tbody></tbody></table>';
+  }
   div.html(h);
 }
 

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -872,7 +872,8 @@ function list_users_data( users, course_array ) {
       if (current_course !== null) {
         ret += '</tbody></table>\n';
       }
-      ret += `<p><b>Primary course: ${course_array[user.primary_course_id].course_name} (${user.primary_course_id})</b></p>\n`;
+      const course_label = (user.primary_course_id === user_primary_course_id) ? 'Primary course' : 'Course';
+      ret += `<p><b>${course_label}: ${course_array[user.primary_course_id].course_name} (${user.primary_course_id})</b></p>\n`;
       ret += '<table><tbody>\n';
       ret += '<tr><th>Name</th><th>Email</th><th>ID</th><th>First Seen</th><th>Last Seen</th></tr>\n';
       current_course = user.primary_course_id;

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -879,7 +879,7 @@ function list_users_data( users, course_array ) {
     return ret;
   }
   users.forEach( user => ( h+= user_html(user) ));
-  h += '</tbody>';
+  h += '</tbody></table>';
   div.html(h);
 }
 

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -872,10 +872,10 @@ function list_users_data( users, course_array ) {
     if (current_course != user.primary_course_id) {
       ret += `<tr><td colspan='4'>&nbsp;</td></tr>\n`;
       ret += `<tr><th colspan='4'>Primary course: ${course_array[user.primary_course_id].course_name} (${user.primary_course_id})</th></tr>\n`;
-      ret += '<tr><th>Name</th><th>Email</th><th>First Seen</th><th>Last Seen</th></tr>\n';
+      ret += '<tr><th>Name</th><th>Email</th><th>ID</th><th>First Seen</th><th>Last Seen</th></tr>\n';
       current_course = user.primary_course_id;
     }
-    ret +=  `<tr><td>${user.user_name} (${user.user_id}) </td><td>${user.email}</td><td>${d1}</td><td>${d2}</td></tr>\n`;
+    ret +=  `<tr><td>${user.user_name}</td><td>${user.email}</td><td>${user.user_id}</td><td>${d1}</td><td>${d2}</td></tr>\n`;
     return ret;
   }
   users.forEach( user => ( h+= user_html(user) ));

--- a/src/app/static/users.js
+++ b/src/app/static/users.js
@@ -7,17 +7,34 @@ import { $ } from "./utils.js";
 // page: /users
 
 function bulk_register_users() {
-    const email_addresses = $('#br_email_addresses').val() || "";
-    if (email_addresses.trim() == '') {
+    const raw_input = $('#br_email_addresses').val() || "";
+    if (raw_input.trim() == '') {
         $('#message').html("<b>Please provide a list of email addresses</b>");
         return;
     }
 
+    // Parse each line as "email" or "email, name"; split only on the first comma
+    const emails = [];
+    const names = [];
+    for (const line of raw_input.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) { continue; }
+        const comma_idx = trimmed.indexOf(',');
+        if (comma_idx === -1) {
+            emails.push(trimmed);
+            names.push('');
+        } else {
+            emails.push(trimmed.slice(0, comma_idx).trim());
+            names.push(trimmed.slice(comma_idx + 1).trim());
+        }
+    }
+
     const payload = {
-        "api_key": api_key, // on the upload form
-        "planttracer_endpoint": window.origin + "", // ToDo: should be a parameter for unit testing
+        "api_key": api_key,
+        "planttracer_endpoint": window.origin + "",
         "course_id": user_primary_course_id,
-        "email-addresses": email_addresses
+        "email-addresses": emails.join('\n'),
+        "names": names.join('\n')
     };
 
     $.post(`${API_BASE}api/bulk-register`, payload)

--- a/src/app/static/users.js
+++ b/src/app/static/users.js
@@ -43,7 +43,7 @@ function bulk_register_users() {
                 $('#message').html('error: ' + data.message);
             } else {
                 $('#message').html(data.message);
-                list_users();
+                window.list_users();
             }
         })
         .fail((error) => {

--- a/src/app/static/users.js
+++ b/src/app/static/users.js
@@ -43,8 +43,7 @@ function bulk_register_users() {
                 $('#message').html('error: ' + data.message);
             } else {
                 $('#message').html(data.message);
-                // Safe to reload here since the request is fully completed
-                // window.location.reload();
+                list_users();
             }
         })
         .fail((error) => {

--- a/src/app/static/users.js
+++ b/src/app/static/users.js
@@ -20,8 +20,6 @@ function bulk_register_users() {
         "email-addresses": email_addresses
     };
 
-    console.log("before fetch");
-
     $.post(`${API_BASE}api/bulk-register`, payload)
         .done((data) => {
             if (data.error !== false) {
@@ -37,7 +35,6 @@ function bulk_register_users() {
             console.error("Bulk register error:", error);
         });
 
-    console.log("after fetch initiated");
 }
 
 function bulk_register_setup() {

--- a/src/app/templates/users.html
+++ b/src/app/templates/users.html
@@ -1,6 +1,20 @@
 <!-- -*- mode: html -*- -->
 {% extends 'base.html' %}
 
+{% block head %}
+<style>
+  #your-users table {
+    border-collapse: collapse;
+  }
+  #your-users th,
+  #your-users td {
+    border: 1px solid #ccc;
+    padding: 4px 8px;
+    text-align: left;
+  }
+</style>
+{% endblock %}
+
 {% block body %}
 
 <h2>Users</h2>

--- a/src/app/templates/users.html
+++ b/src/app/templates/users.html
@@ -27,9 +27,9 @@ Below is a list of all users registered on this system for your course
 
     <p>Put one entry per line. Each line should be an email address optionally
       followed by a comma and the student's name, for example:</p>
-    <pre>alice@example.com, Alice Smith
-bob@example.com
-charlie@example.com, Charlie Brown</pre>
+    <pre>agnes@example.com,Agnes Arber
+brigitte@example.com
+charlie@example.com,Charlie Darwin</pre>
     <p>The name is optional. If omitted, the student's name will be left blank.</p>
 
     <label for='email-addresses'>Email Addresses (and optional names):</label>

--- a/src/app/templates/users.html
+++ b/src/app/templates/users.html
@@ -20,11 +20,9 @@
 <h2>Users</h2>
 
 {% if admin %}
-Below is a list of all of the users in all of the courses in which you
-are an admin.
+Below is a list of all of the users in all of the courses in which you are an admin.
 {% else %}
-Below is a list of all users registered on this system for your course
-{{ primary_course_name }}.
+Below is your user information for course {{ primary_course_name }}.
 {% endif %}
 
 <div id='your-users'></div>

--- a/src/app/templates/users.html
+++ b/src/app/templates/users.html
@@ -22,15 +22,18 @@ Below is a list of all users registered on this system for your course
   <form id="bulk_register_form" class="pure-form pure-form-aligned" action="javascript:void(0)">
     <input id="br_course_id" type="hidden" name="course_id" value="{{user_primary_course_id}}">
 
-    <p>You can register students for your class by entering their email
-      addresses into the text box below.</p>
+    <p>You can register students for your class by entering their information
+      into the text box below.</p>
 
-    <p>Please put each email address on
-      its own line, or separate the email addresses with spaces, commas or
-      semicolons.</p>
+    <p>Put one entry per line. Each line should be an email address optionally
+      followed by a comma and the student's name, for example:</p>
+    <pre>alice@example.com, Alice Smith
+bob@example.com
+charlie@example.com, Charlie Brown</pre>
+    <p>The name is optional. If omitted, the student's name will be left blank.</p>
 
-    <label for='email-addresses'>Email Addresses:</label>
-    <textarea id="br_email_addresses" name='email-addresses' rows=10 cols=50></textarea>
+    <label for='email-addresses'>Email Addresses (and optional names):</label>
+    <textarea id="br_email_addresses" name='email-addresses' rows=10 cols=60></textarea>
 
     <div class='pure-controls'>
       <input id='register-emails-button'

--- a/tests/endpoint_test.py
+++ b/tests/endpoint_test.py
@@ -19,7 +19,7 @@ from app.paths import TEST_DIR, TEST_MOVIE_FILENAME
 from app.constants import __version__,logger
 
 # Fixtures are imported in conftest.py
-from app.odb import API_KEY, COURSE_ID, USER_ID
+from app.odb import API_KEY, COURSE_ID, USER_ID, USER_NAME
 from .constants import ADMIN_EMAIL
 
 FRAME_FILES = glob.glob(os.path.join(TEST_DIR, "data", "frame_*.jpg"))
@@ -94,6 +94,78 @@ def test_bulk_register_invalid_email(client, new_course, mailer_config):
     """
     # TODO: test body
     assert True
+
+def test_bulk_register_with_names(client, new_course, mailer_config):
+    """Verify that names submitted with bulk-register are stored as user_name values."""
+    email_address = 'named_user@example.com'
+    user_name     = 'Alice Example'
+    course_id     = new_course[COURSE_ID]
+    api_key       = odb.make_new_api_key(email=new_course[ADMIN_EMAIL])
+    assert is_api_key(api_key)
+
+    r = client.post('/api/bulk-register',
+                    data={'api_key': api_key,
+                          'course_id': str(course_id),
+                          'email-addresses': email_address,
+                          'names': user_name,
+                          'planttracer-endpoint': 'https://example.com/',
+                         })
+    res = r.json
+    assert res['error'] is False
+    assert res['message'].startswith('Registered 1')
+    registered_user = odb.get_user(user_id=res['user_ids'][0])
+    assert registered_user[USER_NAME] == user_name
+    odb.delete_user(user_id=res['user_ids'][0], purge_movies=True)
+
+
+def test_bulk_register_no_names(client, new_course, mailer_config):
+    """Verify that omitting the names list results in empty string user_name values."""
+    email_address = 'noname_user@example.com'
+    course_id     = new_course[COURSE_ID]
+    api_key       = odb.make_new_api_key(email=new_course[ADMIN_EMAIL])
+    assert is_api_key(api_key)
+
+    r = client.post('/api/bulk-register',
+                    data={'api_key': api_key,
+                          'course_id': str(course_id),
+                          'email-addresses': email_address,
+                          'planttracer-endpoint': 'https://example.com/',
+                         })
+    res = r.json
+    assert res['error'] is False
+    assert res['message'].startswith('Registered 1')
+    registered_user = odb.get_user(user_id=res['user_ids'][0])
+    assert registered_user[USER_NAME] == ''
+    odb.delete_user(user_id=res['user_ids'][0], purge_movies=True)
+
+
+def test_bulk_register_partial_names(client, new_course, mailer_config):
+    """Verify that a names list shorter than email-addresses fills provided names and
+    leaves remaining registrations with empty string user_name values."""
+    email1    = 'partial_named@example.com'
+    email2    = 'partial_noname@example.com'
+    user_name = 'Bob Partial'
+    course_id = new_course[COURSE_ID]
+    api_key   = odb.make_new_api_key(email=new_course[ADMIN_EMAIL])
+    assert is_api_key(api_key)
+
+    r = client.post('/api/bulk-register',
+                    data={'api_key': api_key,
+                          'course_id': str(course_id),
+                          'email-addresses': f'{email1}\n{email2}',
+                          'names': user_name,
+                          'planttracer-endpoint': 'https://example.com/',
+                         })
+    res = r.json
+    assert res['error'] is False
+    assert res['message'].startswith('Registered 2')
+    user0 = odb.get_user(user_id=res['user_ids'][0])
+    user1 = odb.get_user(user_id=res['user_ids'][1])
+    assert user0[USER_NAME] == user_name
+    assert user1[USER_NAME] == ''
+    odb.delete_user(user_id=res['user_ids'][0], purge_movies=True)
+    odb.delete_user(user_id=res['user_ids'][1], purge_movies=True)
+
 
 # TODO: api/bulk-register: invalid course id
 # TODO: api/bulk-register: no mailer configuration

--- a/tests/fixtures/local_aws.py
+++ b/tests/fixtures/local_aws.py
@@ -72,13 +72,12 @@ def local_ddb():
         os.environ[ C.AWS_ACCESS_KEY_ID ] = C.TEST_ACCESS_KEY_ID
         os.environ[ C.AWS_SECRET_ACCESS_KEY ]    = C.TEST_SECRET_ACCESS_KEY
 
-    # If no prefix is specified, create a random test prefix
-    if os.environ.get(C.DYNAMODB_TABLE_PREFIX,'') == '':
-        os.environ[ C.DYNAMODB_TABLE_PREFIX ] = 'test-'+str(uuid.uuid4())[0:4]
-
-    # Wipe and recreate the tables if running locally
+    # Wipe and recreate the tables if running locally.
+    # Always generate a fresh random prefix so tests never touch demo- or any
+    # other existing tables that may be running alongside the test suite.
     created_test_tables = False
     if os.environ[ C.AWS_REGION ] == 'local':
+        os.environ[ C.DYNAMODB_TABLE_PREFIX ] = 'test-'+str(uuid.uuid4())[0:4]
         odbmaint.drop_tables(silent_warnings=True)
         odbmaint.create_tables()
         created_test_tables = True

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -163,3 +163,55 @@ def test_admin_sees_all_enrolled_users(client, new_course):
     http_ids = {u['user_id'] for u in res['users']}
     assert admin_id in http_ids
     assert user_id in http_ids
+
+
+def test_admin_two_courses(client, new_course):
+    """An admin for two courses should see all users from both courses,
+    and both courses should appear in the courses list."""
+    admin_id    = new_course['admin_id']
+    admin_email = new_course[ADMIN_EMAIL]
+    user1_id    = new_course[USER_ID]        # enrolled in course 1 via fixture
+
+    # Create a second course and enroll a distinct user in it
+    course2_id  = 'TestCourse2-' + str(uuid.uuid4())[0:8]
+    course2_key = 'key2-' + str(uuid.uuid4())[0:8]
+    odb.create_course(course_id=course2_id, course_name='Second Course', course_key=course2_key)
+
+    user2_dict  = odb.register_email(email=f'user2-{uuid.uuid4()!s:.8}@example.com',
+                                     user_name='Course2 User',
+                                     course_id=course2_id)
+    user2_id    = user2_dict[USER_ID]
+
+    # Make the fixture admin an admin of the second course too
+    odb.add_course_admin(admin_id=admin_id, course_id=course2_id)
+
+    try:
+        recs         = odb.list_users_courses(user_id=admin_id)
+        returned_ids = {u[USER_ID] for u in recs['users']}
+        course_ids   = {c['course_id'] for c in recs['courses']}
+
+        # All three users (admin + one per course) should be present
+        assert admin_id in returned_ids, "admin should see themselves"
+        assert user1_id in returned_ids, "admin should see user from course 1"
+        assert user2_id in returned_ids, "admin should see user from course 2"
+
+        # Both courses should be in the courses list
+        assert new_course[COURSE_ID] in course_ids, "course 1 should be in courses list"
+        assert course2_id in course_ids,             "course 2 should be in courses list"
+
+        # Verify via the HTTP endpoint too
+        admin_api_key = odb.make_new_api_key(email=admin_email)
+        response  = client.post('/api/list-users', data={'api_key': admin_api_key})
+        res       = response.get_json()
+        assert res['error'] is False
+        http_ids      = {u['user_id'] for u in res['users']}
+        http_course_ids = {c['course_id'] for c in res['courses']}
+        assert admin_id in http_ids
+        assert user1_id in http_ids
+        assert user2_id in http_ids
+        assert course2_id in http_course_ids
+
+    finally:
+        odb.remove_course_admin(admin_id=admin_id, course_id=course2_id)
+        odb.delete_user(user_id=user2_id, purge_movies=True)
+        odb.delete_course(course_id=course2_id)

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -8,7 +8,7 @@ import copy
 from app import odb
 from app import odbmaint
 from app.constants import C,logger
-from app.odb import ExistingCourse_Id, UserExists, COURSE_ID, API_KEY, COURSE_KEY
+from app.odb import ExistingCourse_Id, UserExists, COURSE_ID, API_KEY, COURSE_KEY, USER_ID
 from dbutil import DEMO_COURSE_ID,DEMO_COURSE_NAME,DEFAULT_ADMIN_EMAIL,DEFAULT_ADMIN_NAME,DEMO_USER_EMAIL,DEMO_USER_NAME
 
 # Fixtures are imported in conftest.py
@@ -120,6 +120,31 @@ def test_course_list(client, new_course):
     assert res['error'] is False
     users2 = res['users']
 
-    # There is only an admin in the course. Make sure it is the same
-    assert len(users2) in [1]
+    # Regular user is not an admin: they see only themselves
+    assert len(users2) == 1
     assert users1[0]['user_name'] == users2[0]['user_name']
+
+
+def test_admin_sees_all_enrolled_users(client, new_course):
+    """An admin calling list-users should see every user enrolled in their course,
+    not just themselves (regression test for issue #955)."""
+    admin_id    = new_course['admin_id']
+    admin_email = new_course[ADMIN_EMAIL]
+    user_id     = new_course[USER_ID]
+
+    # Give the admin an API key so they can call the endpoint
+    admin_api_key = odb.make_new_api_key(email=admin_email)
+
+    # list_users_courses via the ODB layer
+    recs = odb.list_users_courses(user_id=admin_id)
+    returned_ids = {u[USER_ID] for u in recs['users']}
+    assert admin_id in returned_ids, "admin should see themselves"
+    assert user_id in returned_ids, "admin should see the enrolled regular user"
+
+    # Verify the same through the HTTP endpoint
+    response = client.post('/api/list-users', data={'api_key': admin_api_key})
+    res = response.get_json()
+    assert res['error'] is False
+    http_ids = {u['user_id'] for u in res['users']}
+    assert admin_id in http_ids
+    assert user_id in http_ids

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -125,6 +125,21 @@ def test_course_list(client, new_course):
     assert users1[0]['user_name'] == users2[0]['user_name']
 
 
+def test_first_last_login_times(client, new_course):
+    """first/last fields in list-users response should be populated after a user has authenticated."""
+    admin_email = new_course[ADMIN_EMAIL]
+    admin_id    = new_course['admin_id']
+
+    # Give the admin an api_key and use it (triggers first_used_at / last_used_at recording)
+    admin_api_key = odb.make_new_api_key(email=admin_email)
+    odb.validate_api_key(admin_api_key)   # simulates a login
+
+    recs = odb.list_users_courses(user_id=admin_id)
+    admin_user = next(u for u in recs['users'] if u[USER_ID] == admin_id)
+    assert admin_user.get('first') is not None, "first should be set after login"
+    assert admin_user.get('last') is not None, "last should be set after login"
+
+
 def test_admin_sees_all_enrolled_users(client, new_course):
     """An admin calling list-users should see every user enrolled in their course,
     not just themselves (regression test for issue #955)."""


### PR DESCRIPTION
## Summary

- Bulk-register API and UI now accept an optional `name` alongside each email address, stored as `user_name` on registration
- Users page textarea updated to accept `email, name` per line with updated instructions
- Users list now shows all enrolled users for admins (was only showing the logged-in user)
- First Seen / Last Seen columns populated from api_keys table login timestamps
- Course sections de-duplicated by sorting users by `primary_course_id`; non-primary courses labeled "Course" instead of "Primary course"
- Inaccurate description text fixed for non-admin users
- Users list refreshes automatically after bulk registration
- Test fixture always generates a fresh DynamoDB prefix to prevent wiping demo tables
- Commit message policy (issue reference required) documented in CLAUDE.md

## Fixed Issues

- fixes #714 — bulk-register API accepts optional names list
- fixes #955 — Users page only showed the logged-in user instead of all enrolled users
- fixes #956 — Users table formatting: borders, left-justify, course heading moved above table
- fixes #957 — Users page bulk-register textarea accepts `email, name` format
- fixes #958 — Users list refreshes after successful bulk registration
- fixes #959 — Document issue-reference requirement in CLAUDE.md
- fixes #960 — First Seen / Last Seen always showed n/a
- fixes #961 — Inaccurate description text for non-admin users
- fixes #962 — Test: verify admin with two courses sees all users from both
- fixes #963 — Duplicate course sections and "Primary course" label shown for all courses
- fixes #964 — Test fixture: always generate a fresh DynamoDB table prefix for local runs

## Test plan

- [ ] `make check` passes (lint + pytest + jscoverage)
- [ ] Admin user on Users page sees all enrolled users grouped by course, each course appearing once
- [ ] Primary course labeled "Primary course", others labeled "Course"
- [ ] Bulk-register with `email, name` lines stores correct user names
- [ ] First Seen / Last Seen columns show real timestamps after users have logged in
- [ ] Running tests with `DYNAMODB_TABLE_PREFIX=demo-` set does not wipe demo tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)