### PR TITLE
Add complete DynamoDB schema doc and Flask API reference

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "timeout": 60,
+            "statusMessage": "Checking Sphinx docs build...",
+            "command": "f=$(jq -r '.tool_input.file_path'); case \"$f\" in */docs/*) ;; *) exit 0 ;; esac; cd /Users/sbarber/git/Plant-Tracer/webapp && output=$(poetry run sphinx-build -W --keep-going -b html docs docs/_build/html 2>&1); rc=$?; if [ $rc -ne 0 ]; then printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"Sphinx docs build warnings/errors after editing %s:\\n%s\"}}' \"$f\" \"$output\"; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/Development/DynamoDB.rst
+++ b/docs/Development/DynamoDB.rst
@@ -5,24 +5,273 @@ The Plant Tracer webapp uses AWS DynamoDB to store:
 
 * The user list
 * The course list
+* The enrollment join table (which users are in which courses)
 * The movie list
-* The per-frame annotations.
+* The per-frame trackpoint annotations
+* API keys and audit logs
 
-Originally this was stored in a MySQL database. We migrated to DynamoDB for cost---most uses of Plant Tracer can fit within the DynamoDB free tier, while the cost for running inside MySQL is upwards of $50/month on AWS. (Plant Tracer was originally developed using Dreamhost's free MySQL service, but that requires that you have a Dreamhost account.)
+Originally this was stored in a MySQL database. We migrated to DynamoDB for cost — most uses of
+Plant Tracer can fit within the DynamoDB free tier, while the cost for running MySQL is upwards of
+$50/month on AWS.
 
-Each DynamoDB database is identified by an Account and a database name. These are specified in environment variables when the Flask application is run. For local development you can use the (AWS DynamoDB local (downloadable version))[https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html]. We recommend using the version that is downloaded as a JAR file.
+Each DynamoDB table is identified by an account and a table name. All table names share a common
+prefix controlled by the ``DYNAMODB_TABLE_PREFIX`` environment variable (e.g. ``demo-``). For local
+development you can use the `AWS DynamoDB local (downloadable version)
+<https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html>`_. We
+recommend using the version downloaded as a JAR file.
+
+The canonical table definitions are in ``src/app/schema.py``. All attribute-name constants are
+defined at the top of ``src/app/odb.py``. Tables are created by ``odbmaint.create_tables()`` and
+dropped by ``odbmaint.drop_tables()`` — used by ``make make-local-demo`` and the test fixtures.
+
+
+Table Summary
+-------------
+
+All table names below are shown without the prefix. With ``DYNAMODB_TABLE_PREFIX=demo-`` the
+``users`` table is named ``demo-users``, etc.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40 20 20
+
+   * - Table
+     - Purpose
+     - Partition Key
+     - Sort Key
+   * - ``users``
+     - One record per registered user
+     - ``user_id``
+     - —
+   * - ``unique_emails``
+     - Enforces email address uniqueness across users
+     - ``email``
+     - —
+   * - ``api_keys``
+     - One record per issued API key (a user may have several)
+     - ``api_key``
+     - —
+   * - ``courses``
+     - One record per course
+     - ``course_id``
+     - —
+   * - ``course_users``
+     - Enrollment join table — which users are in which courses
+     - ``course_id``
+     - ``user_id``
+   * - ``movies``
+     - One record per uploaded movie
+     - ``movie_id``
+     - —
+   * - ``movie_frames``
+     - Per-frame trackpoint annotations
+     - ``movie_id``
+     - ``frame_number``
+   * - ``logs``
+     - Audit log entries
+     - ``log_id``
+     - —
+
+
+Table Details
+-------------
+
+users
+~~~~~
+
+One record per registered user.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Attribute
+     - Type
+     - Description
+   * - ``user_id``
+     - String (PK)
+     - Unique identifier, prefixed ``u`` for regular users, ``ud`` for admins
+   * - ``email``
+     - String
+     - User's email address (unique, enforced via ``unique_emails``)
+   * - ``user_name``
+     - String
+     - Display name; may be blank
+   * - ``created``
+     - Integer
+     - Unix epoch seconds at registration
+   * - ``enabled``
+     - Integer (0/1)
+     - Whether the account is active
+   * - ``primary_course_id``
+     - String
+     - The course the user registered through; used as default context
+   * - ``primary_course_name``
+     - String
+     - Denormalized name of the primary course
+   * - ``courses``
+     - List of strings
+     - All courses the user is enrolled in
+   * - ``admin_for_courses``
+     - List of strings
+     - Courses for which the user has admin privileges
+
+
+api_keys
+~~~~~~~~
+
+One record per issued API key. A user may hold multiple keys (e.g. after re-sending a login link).
+The key is sent as a cookie or POST parameter; the server validates it on every request.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Attribute
+     - Type
+     - Description
+   * - ``api_key``
+     - String (PK)
+     - The key value, a random hex string
+   * - ``user_id``
+     - String
+     - Owner of the key
+   * - ``first_used_at``
+     - Integer
+     - Unix epoch seconds of first use (i.e. first login)
+   * - ``last_used_at``
+     - Integer
+     - Unix epoch seconds of most recent use
+   * - ``enabled``
+     - Integer (0/1)
+     - Whether the key is still valid
+
+**GSI:** ``user_id_idx`` on ``user_id``. Used by ``DDBO.get_user_login_times()`` to aggregate
+first/last login times across all of a user's keys without a table scan.
+
+
+courses
+~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Attribute
+     - Type
+     - Description
+   * - ``course_id``
+     - String (PK)
+     - Unique identifier for the course
+   * - ``course_name``
+     - String
+     - Human-readable course name
+   * - ``course_key``
+     - String
+     - Registration passphrase that students use to self-enroll
+   * - ``admins_for_course``
+     - List of strings
+     - ``user_id`` values of all admins for this course
+   * - ``max_enrollment``
+     - Integer
+     - Maximum number of students allowed to self-register (default 50)
+
+
+course_users
+~~~~~~~~~~~~
+
+A lightweight join table that records which users are enrolled in which courses. Each item has only
+the two key attributes: ``course_id`` (partition key) and ``user_id`` (sort key).
+
+Querying ``course_users`` by ``course_id`` returns all enrolled user IDs efficiently — this is used
+by ``course_enrollments(course_id)`` in ``odb.py``.
+
+.. note::
+
+   ``delete_user()`` does not currently remove ``course_users`` rows for the deleted user,
+   which can leave stale enrollment records. ``list_users_courses()`` handles this defensively
+   by catching ``InvalidUser_Id`` and logging a warning. See issue #968 for the planned fix.
+
+
+movies
+~~~~~~
+
+One record per uploaded movie. Key attributes:
+
+``movie_id``, ``title``, ``description``, ``user_id``, ``course_id``, ``published`` (0/1),
+``deleted`` (0/1), ``status``, ``total_frames``, ``fps``, ``width``, ``height``,
+``movie_data_urn`` (S3 URN of the MP4), ``movie_zipfile_urn``, ``first_frame_urn``,
+``last_frame_tracked``, ``research_use`` (0/1), ``credit_by_name`` (0/1), ``attribution_name``,
+``rotation`` (0/90/180/270 degrees).
+
+See ``src/app/schema.py`` ``Movie`` class for the full schema and constraints.
+
+
+movie_frames
+~~~~~~~~~~~~
+
+Per-frame trackpoint storage. Keyed by ``(movie_id, frame_number)``.
+
+Each record's ``trackpoints`` attribute is a list of objects with fields
+``x``, ``y``, ``label``, ``frame_number``, ``status``, and ``err`` (all defined in the
+``Trackpoint`` class in ``schema.py``).
+
+
+Data Consistency Notes
+----------------------
+
+* **Email uniqueness** is enforced by a transactional write to both ``users`` and
+  ``unique_emails`` at registration time.
+* **Course admin list** (``admins_for_course`` on the course record) is kept in sync with
+  ``admin_for_courses`` on the user record by ``add_course_admin()`` and
+  ``remove_course_admin()``.
+* **Enrollment** (``course_users`` rows) is added by ``register_email()`` but is *not* removed
+  by ``delete_user()``. See issue #968.
+* **Login times** (``first_used_at``, ``last_used_at``) live on ``api_keys``, not ``users``.
+  ``list_users_courses()`` aggregates them per user via the ``user_id_idx`` GSI.
+
+
+Local Development
+-----------------
+
+Use DynamoDB Local (JAR version, port 8000) during development::
+
+    python3 bin/local_services.py dynamodb start
+
+Tables are created with::
+
+    make make-local-demo
+
+or from the ``dbutil`` CLI::
+
+    python3 src/dbutil.py createdb
+
+The table prefix for local development defaults to ``demo-`` unless overridden by
+``DYNAMODB_TABLE_PREFIX``. Test fixtures always generate a fresh ``test-xxxx`` prefix to avoid
+interfering with the demo dataset.
+
 
 Amazon Linux 2023 Development Environment (EC2)
 -----------------------------------------------
-Thankfully, when you are running on AWS, you can use DynamoDB and S3. However:
 
-- You need to create a DynamoDB database for use with Plant Tracer.
-- You need to create an S3 bucket for use with Plant Tracer.
+When running on AWS, you can use real DynamoDB and S3. You will need to:
+
+- Create a DynamoDB set of tables for use with Plant Tracer (``make make-local-demo`` or ``dbutil createdb``).
+- Create an S3 bucket for use with Plant Tracer.
 
 
 Schema and Naming Changes
 -------------------------
-Some naming changes were done for clarity and others due to name conflicts with DynamoDB's query language.
 
-user table:
-`name`  ;-> `user_name`
+Some naming changes were made for clarity or to avoid conflicts with DynamoDB's reserved words.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Old name
+     - New name
+     - Reason
+   * - ``name``
+     - ``user_name``
+     - ``name`` is a DynamoDB reserved word

--- a/docs/Development/DynamoDB.rst
+++ b/docs/Development/DynamoDB.rst
@@ -251,8 +251,8 @@ The table prefix for local development defaults to ``demo-`` unless overridden b
 interfering with the demo dataset.
 
 
-Amazon Linux 2023 Development Environment (EC2)
------------------------------------------------
+EC2 Development Environment
+---------------------------
 
 When running on AWS, you can use real DynamoDB and S3. You will need to:
 

--- a/docs/Development/DynamoDB.rst
+++ b/docs/Development/DynamoDB.rst
@@ -231,35 +231,6 @@ Data Consistency Notes
   ``list_users_courses()`` aggregates them per user via the ``user_id_idx`` GSI.
 
 
-Local Development
------------------
-
-Use DynamoDB Local (JAR version, port 8000) during development::
-
-    python3 bin/local_services.py dynamodb start
-
-Tables are created with::
-
-    make make-local-demo
-
-or from the ``dbutil`` CLI::
-
-    python3 src/dbutil.py createdb
-
-The table prefix for local development defaults to ``demo-`` unless overridden by
-``DYNAMODB_TABLE_PREFIX``. Test fixtures always generate a fresh ``test-xxxx`` prefix to avoid
-interfering with the demo dataset.
-
-
-EC2 Development Environment
----------------------------
-
-When running on AWS, you can use real DynamoDB and S3. You will need to:
-
-- Create a DynamoDB set of tables for use with Plant Tracer (``make make-local-demo`` or ``dbutil createdb``).
-- Create an S3 bucket for use with Plant Tracer.
-
-
 Schema and Naming Changes
 -------------------------
 

--- a/docs/Development/FlaskAPI.md
+++ b/docs/Development/FlaskAPI.md
@@ -93,7 +93,7 @@ Register multiple users at once. Requires the caller to be a course admin.
 | `api_key` | Yes | Must belong to an admin of `course_id` |
 | `course_id` | Yes | Target course |
 | `email-addresses` | Yes | Newline-delimited list of email addresses. Also accepts comma- or semicolon-delimited values. |
-| `names` | No | Newline-delimited list of display names, positionally matched to `email-addresses`. Added in #714. |
+| `names` | No | Newline-delimited list of display names, positionally matched to `email-addresses`. |
 | `planttracer_endpoint` | No | Base URL for login links in emails |
 
 **Response**
@@ -159,7 +159,7 @@ Both routes are equivalent. Return users and courses visible to the caller.
 ```
 
 `first` and `last` are Unix epoch seconds of the user's first and most recent login, respectively
-(aggregated across all their API keys). Both are `null` if the user has never logged in. Added in #960.
+(aggregated across all their API keys). Both are `null` if the user has never logged in.
 
 ---
 

--- a/docs/Development/FlaskAPI.md
+++ b/docs/Development/FlaskAPI.md
@@ -1,0 +1,393 @@
+# Flask API Reference
+
+All REST endpoints served by the Plant Tracer Flask application are defined in
+`src/app/flask_api.py` and mounted at `/api/`. This document covers authentication,
+the standard response envelope, and every endpoint.
+
+For the Lambda (frame/video processing) endpoints, see [ClientLambdaAPI.md](ClientLambdaAPI.md).
+
+---
+
+## Authentication
+
+All endpoints (except `/api/ver` and `/api/config-check`) require an `api_key` parameter.
+Pass it as a POST body field or a query-string parameter.
+
+- Valid key → request proceeds, user identity resolved from the key.
+- Invalid or missing key → `{"error": true, "message": "InvalidAPI_Key"}` with HTTP 200.
+
+API keys are issued per-user and stored in the `api_keys` DynamoDB table. A user may hold
+multiple keys (e.g. after re-sending a login link). Keys are sent as a cookie after first login.
+
+---
+
+## Response Envelope
+
+All endpoints return JSON. Successful responses always include `"error": false`. Error
+responses always include `"error": true` and a `"message"` string explaining the problem.
+
+```json
+{ "error": false, ... }
+{ "error": true, "message": "Human-readable reason" }
+```
+
+---
+
+## Endpoints
+
+### User & Registration
+
+---
+
+#### `POST /api/register`
+
+Register a new user by email address and course key. Sends a login link by email.
+
+**Parameters**
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `email` | Yes | Email address to register |
+| `course_key` | Yes | Course registration passphrase |
+| `name` | No | User's display name |
+| `planttracer_endpoint` | No | Base URL for login link in email (defaults to server hostname) |
+
+**Response**
+
+```json
+{ "error": false, "message": "Registration key sent to alice@example.com ...", "user_id": "u..." }
+```
+
+Returns `error: true` if the email is invalid, the course key is invalid, or the course is full.
+Returns `error: true` (but still registers the user) if the mailer is not configured.
+
+---
+
+#### `POST /api/resend-link`
+
+Resend a login link to an already-registered email address.
+
+**Parameters**
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `email` | Yes | Email address of the existing user |
+| `planttracer_endpoint` | No | Base URL for login link in email |
+
+**Response**
+
+```json
+{ "error": false, "message": "If you have an account, a link was sent. ..." }
+```
+
+Always returns the same message regardless of whether the email exists (prevents enumeration).
+
+---
+
+#### `POST /api/bulk-register`
+
+Register multiple users at once. Requires the caller to be a course admin.
+
+**Parameters**
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `api_key` | Yes | Must belong to an admin of `course_id` |
+| `course_id` | Yes | Target course |
+| `email-addresses` | Yes | Newline-delimited list of email addresses. Also accepts comma- or semicolon-delimited values. |
+| `names` | No | Newline-delimited list of display names, positionally matched to `email-addresses`. Added in #714. |
+| `planttracer_endpoint` | No | Base URL for login links in emails |
+
+**Response**
+
+```json
+{
+  "error": false,
+  "message": "Registered 3 email address(es) and sent login links.",
+  "user_ids": ["u...", "u...", "u..."]
+}
+```
+
+If the mailer is not configured, users are registered but `message` will note the email failure.
+
+---
+
+#### `POST /api/check-api_key`
+
+Validate an API key and return the associated user record.
+
+**Response**
+
+```json
+{ "error": false, "userinfo": { "user_id": "u...", "email": "...", ... } }
+```
+
+---
+
+### User Listing
+
+---
+
+#### `POST /api/list-users`
+#### `POST /api/list-users-courses`
+
+Both routes are equivalent. Return users and courses visible to the caller.
+
+**Behavior by role**
+
+- **Admin:** Returns all users enrolled in every course the caller admins, sorted by
+  `primary_course_id`. Also returns all those courses in the `courses` list.
+- **Non-admin:** Returns only the caller's own user record and their enrolled courses.
+
+**Response**
+
+```json
+{
+  "error": false,
+  "users": [
+    {
+      "user_id": "u...",
+      "user_name": "Alice",
+      "email": "alice@example.com",
+      "primary_course_id": "PlantTracer-101",
+      "courses": ["PlantTracer-101"],
+      "admin_for_courses": [],
+      "first": 1714000000,
+      "last":  1714500000
+    }
+  ],
+  "courses": [
+    { "course_id": "PlantTracer-101", "course_name": "Intro Biology", ... }
+  ]
+}
+```
+
+`first` and `last` are Unix epoch seconds of the user's first and most recent login, respectively
+(aggregated across all their API keys). Both are `null` if the user has never logged in. Added in #960.
+
+---
+
+### Movies
+
+---
+
+#### `POST /api/new-movie`
+
+Create a movie record and obtain a presigned S3 POST URL for uploading the video file.
+After uploading to S3, call the Lambda `start-processing` endpoint.
+
+**Parameters**
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `api_key` | Yes | Must not be the demo key |
+| `title` | No | Movie title |
+| `description` | No | Movie description |
+| `movie_data_sha256` | Yes | SHA-256 hex digest of the video file (64 chars) |
+| `research_use` | No | `"1"` to allow research use |
+| `credit_by_name` | No | `"1"` to allow attribution by name |
+| `attribution_name` | No | Attribution name (only used if `credit_by_name=1`) |
+
+**Response**
+
+```json
+{
+  "error": false,
+  "movie_id": "m...",
+  "presigned_post": {
+    "url": "https://s3.amazonaws.com/...",
+    "fields": { ... }
+  }
+}
+```
+
+---
+
+#### `POST /api/list-movies`
+
+List all movies visible to the caller (their own movies and published movies in their course).
+
+**Response**
+
+```json
+{ "error": false, "movies": [ { "movie_id": "m...", "title": "...", ... } ] }
+```
+
+---
+
+#### `POST /api/get-movie-metadata`
+
+Get metadata and optionally per-frame trackpoints for a specific movie.
+
+**Parameters**
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `api_key` | Yes | |
+| `movie_id` | Yes | |
+| `frame_start` | No | First frame number to return trackpoints for |
+| `frame_count` | No | Number of frames (required if `frame_start` is provided; must be ≥ 1) |
+| `get_all_if_tracking_completed` | No | If `"1"` and tracking is complete, return all frames |
+
+**Response**
+
+```json
+{
+  "error": false,
+  "metadata": { "movie_id": "m...", "title": "...", "status": "...", ... },
+  "frames": {
+    "0": { "markers": [ { "x": 100.0, "y": 200.0, "label": "Apex", ... } ] }
+  }
+}
+```
+
+`frames` is only present when `frame_start` is provided.
+
+---
+
+#### `POST /api/get-movie-trackpoints`
+
+Download all trackpoints for a movie as CSV (default) or JSON.
+
+**Parameters**
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `api_key` | Yes | |
+| `movie_id` | Yes | |
+| `format` | No | `"json"` for JSON; omit for CSV |
+
+**Response:** CSV with columns `frame_number`, `<label> x`, `<label> y` for each marker label.
+With `format=json`: `{ "error": "False", "trackpoint_dicts": [...] }`.
+
+---
+
+#### `POST /api/put-frame-trackpoints`
+
+Write trackpoints for a single frame. Used by the client before requesting re-tracking.
+
+**Parameters**
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `api_key` | Yes | Must not be the demo key |
+| `movie_id` | Yes | |
+| `frame_number` | Yes | Zero-based frame index |
+| `trackpoints` | Yes | JSON array of trackpoint objects: `[{"x": 100.0, "y": 200.0, "label": "Apex"}, ...]` |
+
+**Response**
+
+```json
+{ "error": false, "message": "trackpoints recorded: 2 " }
+```
+
+---
+
+#### `POST /api/rotate-movie`
+
+Set the movie's rotation. Tracking is cleared; Lambda applies the rotation when re-processing.
+
+**Parameters**
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `api_key` | Yes | Must not be the demo key |
+| `movie_id` | Yes | |
+| `rotation` | Yes | Degrees: `0`, `90`, `180`, or `270` |
+
+**Response**
+
+```json
+{ "error": false }
+```
+
+---
+
+#### `POST /api/delete-movie`
+
+Delete or undelete a movie.
+
+**Parameters**
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `api_key` | Yes | Must not be the demo key |
+| `movie_id` | Yes | |
+| `delete` | No | `"1"` (default) to delete, `"0"` to undelete |
+
+**Response**
+
+```json
+{ "error": false }
+```
+
+---
+
+#### `POST /api/set-metadata`
+
+Set a single metadata property on a movie or user record.
+
+**Parameters**
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `api_key` | Yes | |
+| `set_movie_id` | Cond. | Movie to update (provide this or `user_id`) |
+| `user_id` | Cond. | User to update (provide this or `set_movie_id`) |
+| `prop` | Yes | Property name to set |
+| `value` | Yes | New value |
+
+---
+
+### Logging
+
+---
+
+#### `POST /api/get-logs`
+#### `POST /api/get-log`
+
+Return audit log entries. At least one filter is required (`log_user_id`, `course_id`, or `ipaddr`);
+if none is provided, defaults to the caller's own logs.
+
+**Parameters** (all optional filters)
+
+`start_time`, `end_time`, `course_id`, `course_key`, `movie_id`, `log_user_id`, `ipaddr`,
+`count`, `offset`
+
+**Response**
+
+```json
+{ "error": false, "logs": [ { "log_id": "...", "time_t": 1714000000, ... } ] }
+```
+
+---
+
+### Infrastructure
+
+---
+
+#### `GET /api/ver`
+
+Return the application version. No authentication required.
+
+**Response**
+
+```json
+{ "error": false, "version": "0.9.7", ... }
+```
+
+---
+
+#### `GET /api/config-check`
+
+Check DynamoDB connectivity, S3 CORS configuration, and S3 bucket region. No authentication required.
+
+**Response**
+
+```json
+{
+  "dynamodb_ok": true,  "dynamodb_message": "...",
+  "cors_ok": true,      "cors_message": "...",
+  "bucket_region_ok": true, "bucket_region_message": "..."
+}
+```

--- a/docs/Development/FlaskAPI.md
+++ b/docs/Development/FlaskAPI.md
@@ -26,7 +26,7 @@ multiple keys (e.g. after re-sending a login link). Keys are sent as a cookie af
 All endpoints return JSON. Successful responses always include `"error": false`. Error
 responses always include `"error": true` and a `"message"` string explaining the problem.
 
-```json
+```text
 { "error": false, ... }
 { "error": true, "message": "Human-readable reason" }
 ```
@@ -36,8 +36,6 @@ responses always include `"error": true` and a `"message"` string explaining the
 ## Endpoints
 
 ### User & Registration
-
----
 
 #### `POST /api/register`
 
@@ -118,15 +116,13 @@ Validate an API key and return the associated user record.
 
 **Response**
 
-```json
+```text
 { "error": false, "userinfo": { "user_id": "u...", "email": "...", ... } }
 ```
 
 ---
 
 ### User Listing
-
----
 
 #### `POST /api/list-users`
 #### `POST /api/list-users-courses`
@@ -141,7 +137,7 @@ Both routes are equivalent. Return users and courses visible to the caller.
 
 **Response**
 
-```json
+```text
 {
   "error": false,
   "users": [
@@ -169,8 +165,6 @@ Both routes are equivalent. Return users and courses visible to the caller.
 
 ### Movies
 
----
-
 #### `POST /api/new-movie`
 
 Create a movie record and obtain a presigned S3 POST URL for uploading the video file.
@@ -190,7 +184,7 @@ After uploading to S3, call the Lambda `start-processing` endpoint.
 
 **Response**
 
-```json
+```text
 {
   "error": false,
   "movie_id": "m...",
@@ -209,7 +203,7 @@ List all movies visible to the caller (their own movies and published movies in 
 
 **Response**
 
-```json
+```text
 { "error": false, "movies": [ { "movie_id": "m...", "title": "...", ... } ] }
 ```
 
@@ -231,7 +225,7 @@ Get metadata and optionally per-frame trackpoints for a specific movie.
 
 **Response**
 
-```json
+```text
 {
   "error": false,
   "metadata": { "movie_id": "m...", "title": "...", "status": "...", ... },
@@ -341,8 +335,6 @@ Set a single metadata property on a movie or user record.
 
 ### Logging
 
----
-
 #### `POST /api/get-logs`
 #### `POST /api/get-log`
 
@@ -356,7 +348,7 @@ if none is provided, defaults to the caller's own logs.
 
 **Response**
 
-```json
+```text
 { "error": false, "logs": [ { "log_id": "...", "time_t": 1714000000, ... } ] }
 ```
 
@@ -364,15 +356,13 @@ if none is provided, defaults to the caller's own logs.
 
 ### Infrastructure
 
----
-
 #### `GET /api/ver`
 
 Return the application version. No authentication required.
 
 **Response**
 
-```json
+```text
 { "error": false, "version": "0.9.7", ... }
 ```
 

--- a/docs/Development/index.rst
+++ b/docs/Development/index.rst
@@ -21,6 +21,7 @@ Developer Documentation
    MOVIE_METADATA
    ArchitectureDesign
    ClientLambdaAPI
+   FlaskAPI
    ProcessingPhases
    THEORY_OF_DESIGN
    NOTES_ON_SIMPLIFYING


### PR DESCRIPTION
## Summary

- Rewrites `docs/Development/DynamoDB.rst` with complete schema documentation for all 8 tables, GSIs, and data consistency notes
- Adds `docs/Development/FlaskAPI.md`, a new reference covering all 15 `/api/*` endpoints
- Adds a project-level PostToolUse hook (`.claude/settings.json`) that runs `sphinx-build -W` after any edit to `docs/`
- Removes stale Local Development and EC2 Development Environment sections from `DynamoDB.rst`

## Fixed Issues

- Fixes #969 — Update and complete DynamoDB.rst schema documentation
- Fixes #970 — Add Flask API endpoint reference documentation
- Fixes #972 — Add PostToolUse hook to check Sphinx docs build after editing docs/

## Test plan

- [ ] `poetry run sphinx-build -W --keep-going -b html docs docs/_build/html` passes with no warnings
- [ ] Rendered HTML for `DynamoDB` and `FlaskAPI` pages looks correct in browser
- [ ] Hook in `.claude/settings.json` fires and reports Sphinx warnings when a docs file is edited

🤖 Generated with [Claude Code](https://claude.com/claude-code)