### PR TITLE
Add bin/make-targets script

### DIFF
--- a/bin/make-targets
+++ b/bin/make-targets
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Show the targets defined in the Makefile in the current directory.
+set -euo pipefail
+
+if [ ! -f Makefile ]; then
+    echo "No Makefile found in the current directory." >&2
+    exit 1
+fi
+
+grep -E '^[a-zA-Z0-9_-]+[^=]*:([^=]|$)' Makefile \
+    | grep -v '^\.PHONY' \
+    | sed 's/:.*//' \
+    | sort -u


### PR DESCRIPTION
## Summary

- Adds `bin/make-targets`, a bash script that lists all targets defined in the Makefile in the current directory
- Works on any Makefile in the current directory, not just the webapp Makefile
- Outputs targets sorted alphabetically, excluding `.PHONY` declarations

## Test plan

- [ ] Run `bin/make-targets` from the webapp root and verify it lists expected targets
- [ ] Run from a directory with no Makefile and verify it exits with an error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)