### PR TITLE
Bump version to 0.9.7.5.1 and improve release process docs (#982, #983)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,10 +171,10 @@ After tagging, create a GitHub release from the tagged commit. The release title
    gh release create <tag> --title "<Month-DD-YYYY>" --notes "<notes>"
    ```
 
-Each line in the release notes should include the issue/PR number and title, e.g.:
+Each line in the release notes should be a Markdown link to the issue/PR, e.g.:
 ```
-- #930 Documentation: Update UserTutorial to current prod functionality
-- #966 Fix ESLint no-undef error: list_users called bare in users.js
+- [#930](https://github.com/Plant-Tracer/webapp/issues/930) Documentation: Update UserTutorial to current prod functionality
+- [#966](https://github.com/Plant-Tracer/webapp/issues/966) Fix ESLint no-undef error: list_users called bare in users.js
 ```
 
 ## Tagging a Release
@@ -188,9 +188,9 @@ Version tagging is done directly on `main` (not via a PR). Once all PRs for the 
      --milestone "<milestone-name>"
    ```
 
-2. **Tag and push**:
+2. **Tag and push** (always use an annotated tag so the tag carries a message referencing the issue):
    ```bash
-   git tag <tag-name> main
+   git tag -a <tag-name> -m "refs #<issue-number>: tag main as <tag-name>"
    git push origin <tag-name>
    ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "webapp"
-version = "0.9.7.4"
+version = "0.9.7.5.1"
 description = "PlantTracer webapp"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/src/app/constants.py
+++ b/src/app/constants.py
@@ -7,7 +7,7 @@ Constants are created in classes so we can import the class and don't have to im
 import logging
 import os
 
-__version__ = '0.9.7.4'
+__version__ = '0.9.7.5.1'
 
 # these aren't strictly constants...
 log_level = os.getenv("LOG_LEVEL","INFO").upper()


### PR DESCRIPTION
## Summary

- Bumps version to `0.9.7.5.1` in `pyproject.toml` and `src/app/constants.py` (version was never updated for the 0.9.7.5 release)
- Updates `CLAUDE.md` to document that release tags should always be annotated (`git tag -a`)
- Updates `CLAUDE.md` to document that release note issue numbers should be Markdown hyperlinks

Closes #982
Closes #983

## Test plan

- [ ] `make check` passes
- [ ] `python -c "from app.constants import __version__; print(__version__)"` prints `0.9.7.5.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)