### PR TITLE
Fix unpublished movie visibility and default new uploads to published (#927, #987)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Plant Tracer is a Flask-based web application for uploading, managing, and annotating plant growth time-lapse videos at https://prod.planttracer.com/. It has a Python/Flask backend, a JavaScript frontend (jQuery loaded globally, with ES modules importing `$` from `utils.js`), DynamoDB for structured data, and S3 for video/frame storage.
 
+## Documentation
+
+When completing work on any Issue or PR, always review whether documentation under `docs/` needs to be updated to reflect the change. This includes:
+- User-facing docs (`UserTutorial.rst`, etc.)
+- Developer docs (`FlaskAPI.md`, `DynamoDB.rst`, `THEORY_OF_DESIGN.rst`, etc.)
+- Release history (`ReleaseHistory.rst`)
+
+If any screenshots in `docs/tutorial_images/` may be affected, flag them for the user rather than updating them automatically.
+
+After editing any file under `docs/`, always build and verify: `poetry run sphinx-build -W --keep-going -b html docs docs/_build/html`
+
 ## Git Workflow
 
 Never commit or push directly to the `main` branch. All changes must go through a feature branch and be merged via Pull Request. Only proceed with a direct commit to `main` if the user explicitly says to override this rule.
@@ -169,6 +180,11 @@ After tagging, create a GitHub release from the tagged commit. The release title
 5. Create the release:
    ```bash
    gh release create <tag> --title "<Month-DD-YYYY>" --notes "<notes>"
+   ```
+
+**Release titles must be unique.** If more than one release is made on the same day, append a count starting at `-2` (e.g., `May-16-2026`, `May-16-2026-2`, `May-16-2026-3`). Check existing titles first:
+   ```bash
+   gh release list --repo Plant-Tracer/webapp
    ```
 
 Each line in the release notes should be a Markdown link to the issue/PR, e.g.:

--- a/docs/Development/DynamoDB.rst
+++ b/docs/Development/DynamoDB.rst
@@ -198,7 +198,7 @@ movies
 
 One record per uploaded movie. Key attributes:
 
-``movie_id``, ``title``, ``description``, ``user_id``, ``course_id``, ``published`` (0/1),
+``movie_id``, ``title``, ``description``, ``user_id``, ``course_id``, ``published`` (0/1; defaults to 1 on creation),
 ``deleted`` (0/1), ``status``, ``total_frames``, ``fps``, ``width``, ``height``,
 ``movie_data_urn`` (S3 URN of the MP4), ``movie_zipfile_urn``, ``first_frame_urn``,
 ``last_frame_tracked``, ``research_use`` (0/1), ``credit_by_name`` (0/1), ``attribution_name``,

--- a/docs/Development/FlaskAPI.md
+++ b/docs/Development/FlaskAPI.md
@@ -199,7 +199,7 @@ After uploading to S3, call the Lambda `start-processing` endpoint.
 
 #### `POST /api/list-movies`
 
-List all movies visible to the caller (their own movies and published movies in their course).
+List all movies visible to the caller (their own movies and published movies in their course; admins additionally see unpublished movies from other users in their course).
 
 **Response**
 

--- a/docs/Development/THEORY_OF_DESIGN.rst
+++ b/docs/Development/THEORY_OF_DESIGN.rst
@@ -57,7 +57,7 @@ Faculty interface
   * Each faculty member can be in any number of sections
   * Shows all students assigned to each of their section, and all unassigned students.
   * Allows students to be moved between sections and unassigned.
-  * Shows all uploaded movies for each section and allows them to be publisehd or unpublished.
+  * Shows all uploaded movies for each section and allows them to be published or unpublished. Admins can publish or unpublish any movie; non-admin users can unpublish their own movies.
 
 
 API

--- a/src/app/odb.py
+++ b/src/app/odb.py
@@ -1377,7 +1377,7 @@ def create_new_movie(*, user_id, course_id=None, title=None, description=None, o
                     TITLE: title,
                     DESCRIPTION: description,
                     ORIG_MOVIE: orig_movie,
-                    PUBLISHED: 0,
+                    PUBLISHED: 1,
                     DELETED: 0,
                     MOVIE_ZIPFILE_URN: None,
                     MOVIE_DATA_URN: None,

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -814,7 +814,7 @@ function list_movies_data( movies ) {
   movies_fill_div( '#your-unpublished-movies',
                    UNPUBLISHED, movies.filter( m => (m.user_id==user_id && m.published==0 && m.deleted==0 && !m.orig_movie)));
   movies_fill_div( '#course-movies',
-                   COURSE, movies.filter( m => (m.course_id==user_primary_course_id && (demo_mode || (m.user_id!=user_id)) && !m.orig_movie)));
+                   COURSE, movies.filter( m => (m.course_id==user_primary_course_id && (demo_mode || (m.user_id!=user_id)) && !m.orig_movie && (m.published==1 || admin))));
   movies_fill_div( '#your-deleted-movies',
                    DELETED, movies.filter( m => (m.user_id==user_id && m.published==0 && m.deleted==1 && !m.orig_movie)));
   document.querySelectorAll('.movie_player').forEach(el => el.style.display = 'none');

--- a/src/app/templates/list.html
+++ b/src/app/templates/list.html
@@ -73,7 +73,7 @@
 
 <div class="nodemo">
   <h3>Published</h3>
-  <p class='instructions'><i>Published movies can be viewed by anyone in
+  <p class='instructions'><i>Newly uploaded movies are published by default and can be viewed by anyone in
       your course. Click the 'unpublish' button to unpublish a
       movie. Click the 'delete' button to delete a movie.</i></p>
   <div class='mtable' id='your-published-movies'></div>

--- a/tests/fixtures/local_aws.py
+++ b/tests/fixtures/local_aws.py
@@ -178,7 +178,7 @@ def new_movie(new_course):
     movie = odb.get_movie(movie_id = movie_id)
     assert movie[USER_ID] == cfg[USER_ID]
     assert movie[DELETED] == 0
-    assert movie[PUBLISHED] == 0
+    assert movie[PUBLISHED] == 1
     assert movie[VERSION] == 1
 
     cfg[MOVIE_ID] = movie_id

--- a/tests/movie_test.py
+++ b/tests/movie_test.py
@@ -115,13 +115,13 @@ def test_new_movie(client, new_movie):
     count = 0
     logger.debug("movies=%s",movies)
     for movie in movies:
-        if (movie['deleted'] == 0) and (movie['published'] == 0) and (movie['title'] == movie_title):
+        if (movie['deleted'] == 0) and (movie['published'] == 1) and (movie['title'] == movie_title):
             count += 1
             logger.debug("found movie: %s",movie)
         else:
             logger.debug("skip deleted=%s published=%s title=%s ",
                           movie['deleted']==0,
-                          movie['published']==0,
+                          movie['published']==1,
                           movie['title']==movie_title)
     assert count==1
 
@@ -237,8 +237,8 @@ def test_movie_update_metadata(client, new_movie):
     logger.debug("get_movie(%s,%s,%s)=%s",client,api_key,movie_id,movie)
     assert movie['deleted'] == 0
 
-    # Try to publish the movie under the user's API key. This should not work
-    assert get_movie(client, api_key, movie_id)['published'] == 0
+    # Movies are published by default; verify and confirm owner can set published state
+    assert get_movie(client, api_key, movie_id)['published'] == 1
     resp = client.post('/api/set-metadata',
                            data = {'api_key': api_key,
                                    'set_movie_id': movie_id,

--- a/tests/upload_movie_browser_test.py
+++ b/tests/upload_movie_browser_test.py
@@ -54,7 +54,7 @@ def _wait_for_movie_id(driver):
 def _section_contains_title(driver, title):
     """Helper for WebDriverWait to confirm the uploaded title renders on /list."""
     try:
-        section = driver.find_element(By.ID, "your-unpublished-movies")
+        section = driver.find_element(By.ID, "your-published-movies")
         return title in section.get_attribute("innerHTML")
     except Exception:  # pylint: disable=broad-exception-caught
         return False
@@ -118,7 +118,7 @@ def test_upload_movie_end_to_end(chrome_driver, live_server, new_course):
 
     # Confirm movie shows up in the UI list (client-side render)
     chrome_driver.get(f"{live_server}/list")
-    wait.until(EC.presence_of_element_located((By.ID, "your-unpublished-movies")))
+    wait.until(EC.presence_of_element_located((By.ID, "your-published-movies")))
     try:
         assert wait.until(lambda d: _section_contains_title(d, title))
     except TimeoutException:


### PR DESCRIPTION
## Summary

- **#927 (bug fix):** All students in a course could see each other's unpublished movies. The `course-movies` JavaScript filter was missing a check for `m.published==1`, causing all movies to be shown regardless of publication state. Fixed to only show published movies to non-admin users.

- **#987 (feature):** Changed the default publication state for newly uploaded movies from unpublished (0) to published (1), based on feedback that the lab class experience is improved when students can see each other's movies immediately. Users can still unpublish their own movies; only admins can re-publish an unpublished movie.

- Updated `list.html` instruction text to note that new uploads are published by default.

- Updated tests and fixtures to reflect the new `published=1` default.

- **#987 (docs):** Updated `THEORY_OF_DESIGN.rst`, `DynamoDB.rst`, and `FlaskAPI.md` to reflect the published-by-default behavior and clarify that non-admin users can unpublish their own movies.

- **#990 (process):** Added a rule to `CLAUDE.md` requiring that documentation under `docs/` always be reviewed for needed updates when completing any Issue or PR. Also added the unique release title rule (append `-2`, `-3` etc. for multiple same-day releases) discovered during release process work.

Fixes #927
Fixes #987
Closes #990

## Test plan

- [x] `make check` passes (88 pytest, 280 JS tests)
- [ ] Upload a movie as a non-admin student; verify it appears in **Published** section and is visible in other students' course movie list
- [ ] Unpublish a movie as a student; verify it disappears from other students' course movie list
- [ ] Verify admins can still see all movies (published and unpublished) in the course list

🤖 Generated with [Claude Code](https://claude.com/claude-code)