### PR TITLE
Research use radio buttons, contributor agreement, and movie list columns

### DIFF
--- a/docs/Development/DynamoDB.rst
+++ b/docs/Development/DynamoDB.rst
@@ -201,7 +201,7 @@ One record per uploaded movie. Key attributes:
 ``movie_id``, ``title``, ``description``, ``user_id``, ``course_id``, ``published`` (0/1; defaults to 1 on creation),
 ``deleted`` (0/1), ``status``, ``total_frames``, ``fps``, ``width``, ``height``,
 ``movie_data_urn`` (S3 URN of the MP4), ``movie_zipfile_urn``, ``first_frame_urn``,
-``last_frame_tracked``, ``research_use`` (0/1), ``credit_by_name`` (0/1), ``attribution_name``,
+``last_frame_tracked``, ``research_use`` (0/1/None; None = not yet answered), ``credit_by_name`` (0/1/None; None = not yet answered), ``attribution_name``,
 ``rotation`` (0/90/180/270 degrees).
 
 See ``src/app/schema.py`` ``Movie`` class for the full schema and constraints.

--- a/docs/Development/FlaskAPI.md
+++ b/docs/Development/FlaskAPI.md
@@ -178,9 +178,9 @@ After uploading to S3, call the Lambda `start-processing` endpoint.
 | `title` | No | Movie title |
 | `description` | No | Movie description |
 | `movie_data_sha256` | Yes | SHA-256 hex digest of the video file (64 chars) |
-| `research_use` | No | `"1"` to allow research use |
-| `credit_by_name` | No | `"1"` to allow attribution by name |
-| `attribution_name` | No | Attribution name (only used if `credit_by_name=1`) |
+| `research_use` | No | `"1"` = yes, `"0"` = no, omit = not answered |
+| `credit_by_name` | No | `"1"` = yes, `"0"` = no, omit = not answered (only meaningful when `research_use=1`) |
+| `attribution_name` | No | Attribution name (only stored when `credit_by_name=1`) |
 
 **Response**
 
@@ -312,6 +312,27 @@ Delete or undelete a movie.
 **Response**
 
 ```json
+{ "error": false }
+```
+
+---
+
+#### `POST /api/set-research-metadata`
+
+Set `research_use` (and optionally `credit_by_name`) for a movie. Only the movie's uploader may call this endpoint — course admins are not permitted to change another user's research metadata. When `research_use` is set to anything other than `"1"`, `credit_by_name` is automatically cleared server-side; `attribution_name` is left intact.
+
+**Parameters**
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `api_key` | Yes | Must belong to the movie's uploader |
+| `movie_id` | Yes | Movie to update |
+| `research_use` | No | `"1"` = yes, `"0"` = no, omit = not answered |
+| `credit_by_name` | No | `"1"` = yes, `"0"` = no; only applied when `research_use=1` |
+
+**Response**
+
+```text
 { "error": false }
 ```
 

--- a/docs/Development/MOVIE_METADATA.rst
+++ b/docs/Development/MOVIE_METADATA.rst
@@ -30,11 +30,26 @@ that the object remains self-describing even if the DynamoDB database is gone.
 The two main choices are:
 
 1. **Research use** — Whether the uploaded movie may be used in academic
-   research. If not selected, the video is for course use only and is not
-   intended for research.
+   research.
 2. **Credit by name** — If research use is allowed, whether the student wants
    to be credited by name. If yes, a "Name for attribution" value is stored.
    If no, the video may still be used in research but anonymously.
+
+Three-state model
+-----------------
+
+Each of ``research_use`` and ``credit_by_name`` is a three-state value:
+
+- ``1`` — explicitly **Yes**
+- ``0`` — explicitly **No**
+- ``None`` — **not yet answered** (the user did not select a radio button,
+  or the record predates the radio-button UI)
+
+The sentinel string ``"not-answered"`` is used when either field has not been
+answered in S3 object metadata and MP4 embedded metadata (where ``None`` cannot
+be stored directly). Legacy records with ``0`` stored before the radio-button UI
+was introduced are treated as an explicit *No* (the original checkbox was
+visible to the user and they chose not to check it).
 
 Implementation
 ==============
@@ -42,18 +57,14 @@ Implementation
 Upload form
 -----------
 
-- **Checkbox 1:** "The uploaded movie may be used in academic research."
-  When unchecked, the video is not for research use; the second checkbox and
-  name field are hidden.
+- **Research use** — Yes/No radio group. Neither option is pre-selected,
+  leaving the value as *not answered* until the student makes a choice.
 
-- **Checkbox 2:** Shown only when checkbox 1 is checked. "I would like credit
-  by name for the use of this video in research." If unchecked, the video may
-  be used in research anonymously; the "Name for attribution" field is disabled
-  and shows the placeholder "In the text."
+- **Credit by name** — Yes/No radio group. Shown only when research use is
+  **Yes**. Neither option is pre-selected by default.
 
-- **Name for attribution:** Text field, shown when research use is allowed.
-  Enabled only when "credit by name" is checked; otherwise disabled with
-  placeholder "In the text."
+- **Name for attribution:** Text field. Shown and enabled only when both
+  research use is **Yes** and credit by name is **Yes**.
 
 UI logic is implemented in ``sync_attribution_ui()`` in ``src/app/static/planttracer.js``,
 with the form markup in ``src/app/templates/upload.html``.
@@ -62,44 +73,45 @@ API and database
 ----------------
 
 - **Endpoint:** ``POST /api/new-movie`` accepts (in addition to existing
-  parameters) form fields: ``research_use`` (``"1"`` or omitted), ``credit_by_name``
-  (``"1"`` or omitted), and ``attribution_name`` (string).
+  parameters) form fields: ``research_use`` (``"1"``, ``"0"``, or omitted),
+  ``credit_by_name`` (``"1"``, ``"0"``, or omitted), and ``attribution_name``
+  (string). Omitted fields are stored as ``None`` in DynamoDB.
 
 - **Storage:** The movie record in DynamoDB (see ``schema.Movie`` and
   ``odb.create_new_movie``) stores:
 
-  - ``research_use``: 0 or 1
-  - ``credit_by_name``: 0 or 1
+  - ``research_use``: 1, 0, or None
+  - ``credit_by_name``: 1, 0, or None
   - ``attribution_name``: string or null (only meaningful when ``credit_by_name == 1``)
 
-- **Validation:** ``credit_by_name == 0`` forces ``attribution_name`` to
-  null on the server. Existing movies without these fields are treated as
-  default 0 / null (see ``schema.Movie`` defaults and ``fix_movie_prop_value``).
+- **Validation:** ``credit_by_name != 1`` forces ``attribution_name`` to
+  null on the server.
 
 Presigned S3 upload and object metadata
 ---------------------------------------
 
 - **Presigned post:** ``s3_presigned.make_presigned_post()`` takes
-  ``research_use``, ``credit_by_name``, and ``attribution_name`` (as strings
-  for the form). These are added to both ``Fields`` and ``Conditions`` so that
-  the presigned POST signature binds the client to those exact values.
+  ``research_use``, ``credit_by_name``, and ``attribution_name`` (as strings).
+  These are added to both ``Fields`` and ``Conditions`` so that the presigned
+  POST signature binds the client to those exact values.
 
-- **S3 object metadata:** The same values are sent as S3 user metadata in the
-  POST body using the keys:
+- **S3 object metadata:** The same values are sent as S3 user metadata using
+  the keys:
 
-  - ``x-amz-meta-research-use`` (e.g. ``"0"`` or ``"1"``)
-  - ``x-amz-meta-credit-by-name`` (e.g. ``"0"`` or ``"1"``)
-  - ``x-amz-meta-attribution-name`` (string; empty when not attributed by name)
+  - ``x-amz-meta-research-use`` — ``"1"``, ``"0"``, or ``"not-answered"``
+  - ``x-amz-meta-credit-by-name`` — ``"1"``, ``"0"``, or ``"not-answered"``
+  - ``x-amz-meta-attribution-name`` — name string, or empty string
 
   Because they are in the presigned ``Fields``, the client must send these
   exact values when uploading; the object in S3 therefore carries the same
   research and attribution metadata as the DynamoDB record.
 
 - **Client:** ``upload_movie_post()`` in ``planttracer.js`` sends
-  ``research_use``, ``credit_by_name``, and ``attribution_name`` to
-  ``/api/new-movie``. The API returns a presigned post whose ``fields``
-  already contain the signed metadata; the client posts those fields (and the
-  file) to S3 without modifying them.
+  ``research_use`` and ``credit_by_name`` only when a radio button has been
+  selected (omits the field entirely when *not answered*), and sends
+  ``attribution_name`` to ``/api/new-movie``. The API returns a presigned post
+  whose ``fields`` already contain the signed metadata; the client posts those
+  fields (and the file) to S3 without modifying them.
 
 Traceability
 ------------

--- a/docs/UserTutorial.rst
+++ b/docs/UserTutorial.rst
@@ -37,11 +37,11 @@ Uploading Movies (optional)
 - Plant Tracer will accept videos in most well-known video file formats, but MP4 is probably best.
 - To upload your movie, select Upload from the menu bar at the top of the browser frame.
 - Enter the title of the file and a description of the movie.
-- If you would like to permit your uploaded movie to be used in academic research, check the box "The uploaded movie may be used in academic research." You will then be asked whether you want to be credited for this contribution and what name you want to be credited with.
+- The upload form asks whether your movie may be used in academic research. Before answering, review the `Contributor Agreement <tos#contributor-agreement>`_ linked on the form. Select **Yes** or **No**. If you select **Yes**, you will also be asked whether you want to be credited by name; your display name is pre-filled as the attribution name, which you can edit.
 - Choose a file to upload.
 
 .. image:: tutorial_images/upload_movie.png
-   :alt: Plant Tracer Upload page with fields for movie title, description, research consent checkbox, and file chooser
+   :alt: Plant Tracer Upload page with fields for movie title, description, research use radio buttons, and file chooser
 
 Tracking the Uploaded Movie
 ---------------------------

--- a/src/app/flask_api.py
+++ b/src/app/flask_api.py
@@ -615,6 +615,39 @@ def api_get_log():
 ################################################################
 ## Metdata Management (movies and users, it's a common API!)
 
+@api_bp.route('/set-research-metadata', methods=POST)
+def api_set_research_metadata():
+    """Set research_use (and cascade-clear credit_by_name when not Yes) for a movie.
+    Only the movie's uploader may call this.
+
+    :param api_key: authorization key
+    :param movie_id: the movie to update
+    :param research_use: '1', '0', or absent (None)
+    :param credit_by_name: '1', '0', or absent (None); only applied when research_use == '1'
+    :return: {error: false}
+    """
+    def _parse_tristate(raw):
+        if raw == '1':
+            return 1
+        if raw == '0':
+            return 0
+        return None
+
+    movie_id = get_movie_id()
+    user_id = get_user_id(allow_demo=False)
+    research_use = _parse_tristate(get('research_use'))
+    odb.set_research_use(user_id=user_id, movie_id=movie_id, research_use=research_use)
+
+    # If research is allowed, also update credit_by_name when explicitly provided
+    if research_use == 1:
+        credit_raw = get('credit_by_name')
+        if credit_raw in ('0', '1'):
+            credit_by_name = _parse_tristate(credit_raw)
+            odb.set_metadata(user_id=user_id, set_movie_id=movie_id,
+                             prop='credit_by_name', value=credit_by_name)
+    return {'error': False}
+
+
 @api_bp.route('/set-metadata', methods=POST)
 def api_set_metadata():
     """ set some aspect of the metadata

--- a/src/app/flask_api.py
+++ b/src/app/flask_api.py
@@ -311,12 +311,20 @@ def api_new_movie():
 
     ret = {'error': False}
 
-    research_use = 1 if get('research_use') == '1' else 0
-    credit_by_name = 1 if get('credit_by_name') == '1' else 0
+    def _parse_tristate(raw):
+        """Return 1, 0, or None from a form string value ('1', '0', or absent/other)."""
+        if raw == '1':
+            return 1
+        if raw == '0':
+            return 0
+        return None
+
+    research_use = _parse_tristate(get('research_use'))
+    credit_by_name = _parse_tristate(get('credit_by_name'))
     attribution_name = (request.values.get('attribution_name') or '').strip() or None
     if attribution_name is not None:
         attribution_name = attribution_name[:256]
-    if credit_by_name == 0:
+    if credit_by_name != 1:
         attribution_name = None
 
     ret[MOVIE_ID] = odb.create_new_movie(user_id=user_id,
@@ -335,12 +343,18 @@ def api_new_movie():
 
     # Always upload to final key
     upload_urn = movie_data_urn
+    def _tristate_to_str(val):
+        """Convert tristate int|None to S3 metadata string."""
+        if val is None:
+            return 'not-answered'
+        return str(val)
+
     ret['presigned_post'] = make_presigned_post(
         urn=upload_urn,
         mime_type='video/mp4',
         sha256=movie_data_sha256,
-        research_use=str(research_use),
-        credit_by_name=str(credit_by_name),
+        research_use=_tristate_to_str(research_use),
+        credit_by_name=_tristate_to_str(credit_by_name),
         attribution_name=attribution_name or '')
     return ret
 

--- a/src/app/odb.py
+++ b/src/app/odb.py
@@ -1350,7 +1350,7 @@ def can_access_movie(*, user_id, movie_id):
     raise UnauthorizedUser(f"user {user_id} attempted to access movie {movie_id}")
 
 def create_new_movie(*, user_id, course_id=None, title=None, description=None, orig_movie=None,
-                     research_use=0, credit_by_name=0, attribution_name=None):
+                     research_use=None, credit_by_name=None, attribution_name=None):
     """
     Creates an entry for a new movie and returns the movie_id. The movie content must be uploaded separately.
 
@@ -1358,8 +1358,8 @@ def create_new_movie(*, user_id, course_id=None, title=None, description=None, o
     :param title: - title of movie. Stored in movies table
     :param description: - description of movie
     :param orig_movie: - if presented, the movie_id of the movie on which this is based
-    :param research_use: - 1 if movie may be used in academic research, else 0
-    :param credit_by_name: - 1 if user wants credit by name in research, else 0
+    :param research_use: - 1 if movie may be used in research, 0 if not, None if not yet answered
+    :param credit_by_name: - 1 if user wants credit by name, 0 if anonymous, None if not yet answered
     :param attribution_name: - name for attribution when credit_by_name is 1, else None
     :return: movie_id of the created movie
 

--- a/src/app/odb.py
+++ b/src/app/odb.py
@@ -1395,6 +1395,22 @@ def create_new_movie(*, user_id, course_id=None, title=None, description=None, o
                     })
     return movie_id
 
+def set_research_use(*, user_id, movie_id, research_use):
+    """Set research_use for a movie (owner only). If research_use is not 1, also clears credit_by_name.
+
+    :param user_id: - user making the change; must be the movie owner
+    :param movie_id: - the movie to update
+    :param research_use: - 1, 0, or None
+    """
+    ddbo = DDBO()
+    movie = ddbo.get_movie(movie_id)
+    if movie[USER_ID] != user_id:
+        raise UnauthorizedUser(f"user {user_id} is not the owner of movie {movie_id}")
+    update = {RESEARCH_USE: research_use}
+    if research_use != 1:
+        update[CREDIT_BY_NAME] = None
+    ddbo.update_table(ddbo.movies, movie_id, update)
+
 def get_movie(*, movie_id):
     """Returns the movie's data"""
     return DDBO().get_movie(movie_id)
@@ -1673,6 +1689,10 @@ SET_MOVIE_METADATA = {
 
     # Preview rotation (0–3); applied when tracking (rotate/scale then save as processed movie).
     ROTATION_STEPS: 'update movies set rotation_steps=%s where id=%s and (@is_owner or @is_admin)',
+
+    # Research attribution — only the uploader may change these, not admins of other users' movies.
+    RESEARCH_USE: 'update movies set research_use=%s where id=%s and @is_owner',
+    CREDIT_BY_NAME: 'update movies set credit_by_name=%s where id=%s and @is_owner',
 }
 
 def set_metadata(*, user_id, set_movie_id=None, set_user_id=None, prop, value):

--- a/src/app/s3_presigned.py
+++ b/src/app/s3_presigned.py
@@ -115,7 +115,7 @@ def make_signed_url(*,urn,operation=C.GET, expires=3600):
         ExpiresIn=expires)
 
 def make_presigned_post(*, urn, maxsize=C.MAX_FILE_UPLOAD, mime_type='video/mp4', sha256=None, expires=3600,
-                        research_use='0', credit_by_name='0', attribution_name=''):
+                        research_use='not-answered', credit_by_name='not-answered', attribution_name=''):
     """Returns a dictionary with 'url' and 'fields'.
     research_use, credit_by_name, attribution_name are included in the signature and set as S3 object metadata.
     Uses the bucket's region so the presigned URL is regional and S3 does not 307-redirect (avoids connection

--- a/src/app/schema.py
+++ b/src/app/schema.py
@@ -112,8 +112,9 @@ class Movie(BaseModel):
     version: Annotated[int | None, Field(ge=0)] = None
 
     # Research use and attribution (see docs/MOVIE_METADATA)
-    research_use: Annotated[int, Field(ge=0, le=1)] = 0
-    credit_by_name: Annotated[int, Field(ge=0, le=1)] = 0
+    # None means the user was never asked (legacy or upload without the radio buttons answered).
+    research_use: Annotated[int, Field(ge=0, le=1)] | None = None
+    credit_by_name: Annotated[int, Field(ge=0, le=1)] | None = None
     attribution_name: str | None = None
 
     # Preview rotation on upload page (0–3 × 90° CW). Applied when tracking.

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -675,7 +675,7 @@ function action_button_clicked( e ) {
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
 
 //                           #1          #2               #3               #4              #5                 #6                #7              #8            #9
-const TABLE_HEAD = "<tr> <th>user</th>  <th>uploaded</th> <th>title</th> <th>description</th> <th>size</th> <th>status and action</th> <th>Research Use</th> <th>Credit</th> </tr>";
+const TABLE_HEAD = "<tr> <th>user</th>  <th>uploaded</th> <th>title</th> <th>description</th> <th>size</th> <th>status and action</th> <th>research use</th> <th>credit</th> </tr>";
 
 // Phase 3: list shows movie status. Eventually this list should be server-rendered (Jinja2).
 function list_movies_data( movies ) {
@@ -872,7 +872,7 @@ function list_movies_data( movies ) {
 
     // Offer to upload movies if not in demo mode.
     if (!demo_mode) {
-      h += '<tr><td colspan="6"><a href="/upload">Click here to upload a movie</a></td></tr>';
+      h += '<tr><td colspan="8"><a href="/upload">Click here to upload a movie</a></td></tr>';
     }
 
     h += "</tbody>";

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -553,6 +553,40 @@ function set_property(user_id, movie_id, property, value)
 }
 
 
+// Called when a research_use or credit_by_name dropdown changes.
+// Sends both values to /api/set-research-metadata and redraws.
+function research_metadata_changed( e ) {
+  const movie_id  = e.getAttribute('x-movie_id');
+  const property  = e.getAttribute('x-property');
+  const rawVal    = e.value; // 'n/a', '1', or '0'
+
+  // Find the sibling select for the other field (both carry x-movie_id)
+  function selectVal(prop) {
+    const el = document.querySelector(`select[x-movie_id='${movie_id}'][x-property='${prop}']`);
+    return el ? el.value : 'n/a';
+  }
+
+  const researchRaw = property === 'research_use' ? rawVal : selectVal('research_use');
+  const creditRaw   = property === 'credit_by_name' ? rawVal : selectVal('credit_by_name');
+
+  const formData = new FormData();
+  formData.append('api_key', api_key);
+  formData.append('movie_id', movie_id);
+  if (researchRaw !== 'n/a') { formData.append('research_use', researchRaw); }
+  if (creditRaw   !== 'n/a') { formData.append('credit_by_name', creditRaw); }
+
+  fetch(`${API_BASE}api/set-research-metadata`, { method: 'POST', body: formData })
+    .then((r) => r.json())
+    .then((data) => {
+      if (data.error !== false) {
+        $('#message').html('error: ' + data.message);
+      } else {
+        list_ready_function();
+      }
+    })
+    .catch(console.error);
+}
+
 // This is called when a checkbox in a movie table is checked. It gets the movie_id and the property and
 // the old value and asks for a change. the value 'checked' is the new value, so we just send it to the server
 // and then do a repaint.
@@ -636,8 +670,8 @@ function action_button_clicked( e ) {
 // It's called with a list of movies
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
 
-//                           #1          #2               #3               #4              #5                 #6                #7
-const TABLE_HEAD = "<tr> <th>user</th>  <th>uploaded</th> <th>title</th> <th>description</th> <th>size</th> <th>status and action</th> </tr>";
+//                           #1          #2               #3               #4              #5                 #6                #7              #8            #9
+const TABLE_HEAD = "<tr> <th>user</th>  <th>uploaded</th> <th>title</th> <th>description</th> <th>size</th> <th>status and action</th> <th>Research Use</th> <th>Credit</th> </tr>";
 
 // Phase 3: list shows movie status. Eventually this list should be server-rendered (Jinja2).
 function list_movies_data( movies ) {
@@ -685,6 +719,32 @@ function list_movies_data( movies ) {
       // This products the HTML for each <td> that has a checkbox.
       // Clicking the checkbox calls row_checkbox_clicked(this) to change the property on the server
       // and initiate a redraw
+      // Returns "Yes", "No", or "N/A" for a tristate int|null value
+      function tristate_label(value) {
+        if (value === 1) { return 'Yes'; }
+        if (value === 0) { return 'No'; }
+        return 'N/A';
+      }
+
+      // Produces a <td> for a tristate field.
+      // Owners get a <select> dropdown; everyone else gets read-only text.
+      // The <select> carries x-movie_id and x-property for the change handler.
+      function make_td_tristate(property, value, disabled) {
+        tid += 1;
+        const label = tristate_label(value);
+        if (m.user_id === user_id && !demo_mode && !disabled) {
+          const sel1 = value === 1 ? 'selected' : '';
+          const sel0 = value === 0 ? 'selected' : '';
+          const selN = (value === null || value === undefined) ? 'selected' : '';
+          return `<td><select id='${tid}' x-movie_id='${movie_id}' x-property='${property}' onchange='research_metadata_changed(this)'>` +
+            `<option value='n/a' ${selN}>N/A</option>` +
+            `<option value='1'   ${sel1}>Yes</option>` +
+            `<option value='0'   ${sel0}>No</option>` +
+            `</select></td>\n`;
+        }
+        return `<td>${label}</td>\n`;
+      }
+
       function _make_td_checkbox(property, value) {
         // for debugging:
         // return `<td> ${property} = ${value} </td>`;
@@ -778,11 +838,20 @@ function list_movies_data( movies ) {
           rows += make_action_button( DELETE_BUTTON );
         }
       }
-      rows += "</td></tr>\n"; // #7 end, <tr>
+      rows += "</td>"; // #7 end (status)
+
+      // #8 Research Use — dropdown for owner, text for others
+      rows += make_td_tristate('research_use', m.research_use, false);
+
+      // #9 Credit — dropdown for owner only when research_use==1; otherwise read-only
+      const creditDisabled = (m.research_use !== 1);
+      rows += make_td_tristate('credit_by_name', creditDisabled ? null : m.credit_by_name, creditDisabled);
+
+      rows += "</tr>\n";
 
       // Now make the player row
       rows += `<tr    class='movie_player' id='tr-${rowid}'> `+
-        `<td    class='movie_player' id='td-${rowid}' colspan='7' ></td>` +
+        `<td    class='movie_player' id='td-${rowid}' colspan='8' ></td>` +
         `</tr>\n`;
       return rows;
     }
@@ -928,6 +997,7 @@ window.play_clicked = play_clicked;
 window.analyze_clicked = analyze_clicked;
 window.row_pencil_clicked = row_pencil_clicked;
 window.action_button_clicked = action_button_clicked;
+window.research_metadata_changed = research_metadata_changed;
 window.hide_clicked = hide_clicked;
 
 // Wire up whatever happens to be present
@@ -952,6 +1022,7 @@ if (typeof module != 'undefined'){
     purge_movie,
     register_func,
     resend_func,
+    research_metadata_changed,
     row_checkbox_clicked,
     set_property,
     upload_movie_post,

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -569,11 +569,15 @@ function research_metadata_changed( e ) {
   const researchRaw = property === 'research_use' ? rawVal : selectVal('research_use');
   const creditRaw   = property === 'credit_by_name' ? rawVal : selectVal('credit_by_name');
 
+  // Guard: ignore placeholder value (should never be selectable, but be safe)
+  if (!researchRaw && property === 'research_use') { return; }
+  if (!creditRaw   && property === 'credit_by_name') { return; }
+
   const formData = new FormData();
   formData.append('api_key', api_key);
   formData.append('movie_id', movie_id);
-  if (researchRaw !== 'n/a') { formData.append('research_use', researchRaw); }
-  if (creditRaw   !== 'n/a') { formData.append('credit_by_name', creditRaw); }
+  if (researchRaw) { formData.append('research_use', researchRaw); }
+  if (creditRaw)   { formData.append('credit_by_name', creditRaw); }
 
   fetch(`${API_BASE}api/set-research-metadata`, { method: 'POST', body: formData })
     .then((r) => r.json())
@@ -727,19 +731,21 @@ function list_movies_data( movies ) {
       }
 
       // Produces a <td> for a tristate field.
-      // Owners get a <select> dropdown; everyone else gets read-only text.
-      // The <select> carries x-movie_id and x-property for the change handler.
+      // Owners get a Yes/No <select>; everyone else gets read-only text.
+      // N/A is never an option — when the current value is N/A a disabled placeholder
+      // "—" is shown as the selected item so the user can only move forward to Yes or No.
       function make_td_tristate(property, value, disabled) {
         tid += 1;
         const label = tristate_label(value);
         if (m.user_id === user_id && !demo_mode && !disabled) {
           const sel1 = value === 1 ? 'selected' : '';
           const sel0 = value === 0 ? 'selected' : '';
-          const selN = (value === null || value === undefined) ? 'selected' : '';
+          const placeholder = (value !== 1 && value !== 0)
+            ? `<option value='' disabled selected>—</option>` : '';
           return `<td><select id='${tid}' x-movie_id='${movie_id}' x-property='${property}' onchange='research_metadata_changed(this)'>` +
-            `<option value='n/a' ${selN}>N/A</option>` +
-            `<option value='1'   ${sel1}>Yes</option>` +
-            `<option value='0'   ${sel0}>No</option>` +
+            placeholder +
+            `<option value='1' ${sel1}>Yes</option>` +
+            `<option value='0' ${sel0}>No</option>` +
             `</select></td>\n`;
         }
         return `<td>${label}</td>\n`;

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -118,26 +118,26 @@ function check_upload_metadata()
 }
 
 function sync_attribution_ui() {
-  if ($('#research-use-checkbox').get(0) == null) {
+  if ($('input[name="research_use"]').length === 0) {
     return;
   }
-  const researchChecked = $('#research-use-checkbox').prop('checked');
-  if (researchChecked) {
+  const researchVal = $('input[name="research_use"]:checked').val(); // '1', '0', or undefined
+  if (researchVal === '1') {
     $('#attribution-group').show();
-    $('#attribution-name-group').show();
-    const creditChecked = $('#credit-by-name-checkbox').prop('checked');
+    const creditVal = $('input[name="credit_by_name"]:checked').val(); // '1', '0', or undefined
     const nameInput = $('#attribution-name');
-    if (creditChecked) {
+    if (creditVal === '1') {
+      $('#attribution-name-group').show();
       nameInput.prop('disabled', false);
       nameInput.attr('placeholder', '');
     } else {
-      nameInput.prop('disabled', true);
-      nameInput.attr('placeholder', 'In the text');
+      $('#attribution-name-group').hide();
+      nameInput.val('').prop('disabled', true).attr('placeholder', 'In the text');
     }
   } else {
     $('#attribution-group').hide();
     $('#attribution-name-group').hide();
-    $('#credit-by-name-checkbox').prop('checked', false);
+    $('input[name="credit_by_name"]').prop('checked', false);
     $('#attribution-name').val('').prop('disabled', true).attr('placeholder', 'In the text');
   }
 }
@@ -218,8 +218,8 @@ async function upload_movie_post(movie_title, description, movieFile, research_u
   formData.append("description", description);
   formData.append("movie_data_sha256",  movie_data_sha256);
   formData.append("movie_data_length",  movieFile.size);
-  formData.append("research_use", research_use ? "1" : "0");
-  formData.append("credit_by_name", credit_by_name ? "1" : "0");
+  if (research_use !== null) { formData.append("research_use", research_use); }
+  if (credit_by_name !== null) { formData.append("credit_by_name", credit_by_name); }
   formData.append("attribution_name", attribution_name || "");
   const r = await fetch(`${API_BASE}api/new-movie`, { method:"POST", body:formData});
   const obj = await r.json();
@@ -351,9 +351,9 @@ function upload_movie()
   const description = $('#movie-description').val();
   const movieFileInput = $('#movie-file');
   const movieFile = movieFileInput.prop('files')[0];
-  const research_use = $('#research-use-checkbox').prop('checked');
-  const credit_by_name = $('#credit-by-name-checkbox').prop('checked');
-  const attribution_name = research_use && credit_by_name ? ($('#attribution-name').val() || '').trim() : '';
+  const research_use = $('input[name="research_use"]:checked').val() || null;   // '1', '0', or null
+  const credit_by_name = $('input[name="credit_by_name"]:checked').val() || null; // '1', '0', or null
+  const attribution_name = (research_use === '1' && credit_by_name === '1') ? ($('#attribution-name').val() || '').trim() : '';
 
   if (movie_title.length < 3) {
     $('#message').html('<b>Movie title must be at least 3 characters long');

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -123,6 +123,7 @@ function sync_attribution_ui() {
   }
   const researchVal = $('input[name="research_use"]:checked').val(); // '1', '0', or undefined
   if (researchVal === '1') {
+    $('#contributor-agreement-notice').show();
     $('#attribution-group').show();
     const creditVal = $('input[name="credit_by_name"]:checked').val(); // '1', '0', or undefined
     const nameInput = $('#attribution-name');
@@ -135,6 +136,7 @@ function sync_attribution_ui() {
       nameInput.val('').prop('disabled', true).attr('placeholder', 'In the text');
     }
   } else {
+    $('#contributor-agreement-notice').hide();
     $('#attribution-group').hide();
     $('#attribution-name-group').hide();
     $('input[name="credit_by_name"]').prop('checked', false);

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -123,7 +123,6 @@ function sync_attribution_ui() {
   }
   const researchVal = $('input[name="research_use"]:checked').val(); // '1', '0', or undefined
   if (researchVal === '1') {
-    $('#contributor-agreement-notice').show();
     $('#attribution-group').show();
     const creditVal = $('input[name="credit_by_name"]:checked').val(); // '1', '0', or undefined
     const nameInput = $('#attribution-name');
@@ -136,7 +135,6 @@ function sync_attribution_ui() {
       nameInput.val('').prop('disabled', true).attr('placeholder', 'In the text');
     }
   } else {
-    $('#contributor-agreement-notice').hide();
     $('#attribution-group').hide();
     $('#attribution-name-group').hide();
     $('input[name="credit_by_name"]').prop('checked', false);

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -129,16 +129,15 @@ function sync_attribution_ui() {
     if (creditVal === '1') {
       $('#attribution-name-group').show();
       nameInput.prop('disabled', false);
-      nameInput.attr('placeholder', '');
     } else {
       $('#attribution-name-group').hide();
-      nameInput.val('').prop('disabled', true).attr('placeholder', 'In the text');
+      nameInput.prop('disabled', true);
     }
   } else {
     $('#attribution-group').hide();
     $('#attribution-name-group').hide();
     $('input[name="credit_by_name"]').prop('checked', false);
-    $('#attribution-name').val('').prop('disabled', true).attr('placeholder', 'In the text');
+    $('#attribution-name').prop('disabled', true);
   }
 }
 

--- a/src/app/templates/tos.html
+++ b/src/app/templates/tos.html
@@ -29,4 +29,29 @@
   <a href="privacy">Plant Tracer Privacy Policy</a>
 </p>
 
+<hr>
+<h2 id="contributor-agreement">Contributor Agreement — Research Use of Uploaded Movies</h2>
+
+<p>This section applies to users who choose to make their uploaded movies available for academic
+research when using the Plant Tracer upload form.</p>
+
+<p>By selecting <strong>Yes</strong> to &quot;May this movie be used in academic research?&quot;
+you grant any person obtaining a copy of your uploaded movie a non-exclusive, royalty-free,
+worldwide license to use, reproduce, and distribute that movie for academic research purposes.</p>
+
+<p>This license is <strong>non-exclusive</strong>: you retain full ownership of your movie and
+may continue to use it however you wish. You may not revoke this license for copies already
+distributed, but you may decline research use for any future uploads.</p>
+
+<p>If you additionally select <strong>Yes</strong> to &quot;Would you like credit by name?&quot;
+you consent to your name being included in research credits, acknowledgements, and publications
+that make use of your movie.</p>
+
+<p>If you select <strong>No</strong> for credit by name, your movie may still be used in
+research but will be attributed anonymously.</p>
+
+<p><em>Note: The Plant Tracer Project makes no warranties regarding how third parties will use
+movies made available for research. The contributor agreement text above should be reviewed by
+qualified legal counsel before relying on it.</em></p>
+
 {% endblock %}

--- a/src/app/templates/tos.html
+++ b/src/app/templates/tos.html
@@ -50,8 +50,5 @@ that make use of your movie.</p>
 <p>If you select <strong>No</strong> for credit by name, your movie may still be used in
 research but will be attributed anonymously.</p>
 
-<p><em>Note: The Plant Tracer Project makes no warranties regarding how third parties will use
-movies made available for research. The contributor agreement text above should be reviewed by
-qualified legal counsel before relying on it.</em></p>
 
 {% endblock %}

--- a/src/app/templates/upload.html
+++ b/src/app/templates/upload.html
@@ -41,6 +41,10 @@
         <label style='margin-left:0.75em'><input type='radio' name='research_use' value='1' onchange='sync_attribution_ui()'> Yes</label>
         <label style='margin-left:0.5em'><input type='radio' name='research_use' value='0' onchange='sync_attribution_ui()'> No</label>
       </div>
+      <div id='contributor-agreement-notice' style='display:none; margin: 0.2em 0 0.4em 1em'>
+        <small>By selecting Yes you agree to the
+          <a href='tos#contributor-agreement' target='_blank'>Contributor Agreement</a>.</small>
+      </div>
       <div id='attribution-group' style='display:none; margin: 0.4em 0 0.4em 1em'>
         Would you like credit by name for the use of this video in research?
         <label style='margin-left:0.75em'><input type='radio' name='credit_by_name' value='1' onchange='sync_attribution_ui()'> Yes</label>

--- a/src/app/templates/upload.html
+++ b/src/app/templates/upload.html
@@ -37,17 +37,22 @@
         <span class="pure-form-message-inline">required</span>
       </div>
       <div class='pure-control-group'>
-        <label>
-          <input type='checkbox' id='research-use-checkbox' name='research_use' value='1' onchange='sync_attribution_ui()'>
-          The uploaded movie may be used in academic research.
+        <label>May this movie be used in academic research?</label>
+        <label class='pure-radio'>
+          <input type='radio' name='research_use' value='1' onchange='sync_attribution_ui()'> Yes
+        </label>
+        <label class='pure-radio'>
+          <input type='radio' name='research_use' value='0' onchange='sync_attribution_ui()'> No
         </label>
       </div>
       <div class='pure-control-group' id='attribution-group' style='display:none'>
-        <label>
-          <input type='checkbox' id='credit-by-name-checkbox' name='credit_by_name' value='1' onchange='sync_attribution_ui()'>
-          I would like credit by name for the use of this video in research.
+        <label>Would you like credit by name for the use of this video in research?</label>
+        <label class='pure-radio'>
+          <input type='radio' name='credit_by_name' value='1' onchange='sync_attribution_ui()'> Yes
         </label>
-        <span class="pure-form-message-inline">If unchecked, video will be used anonymously.</span>
+        <label class='pure-radio'>
+          <input type='radio' name='credit_by_name' value='0' onchange='sync_attribution_ui()'> No (video used anonymously)
+        </label>
       </div>
       <div class='pure-control-group' id='attribution-name-group' style='display:none'>
         <label for='attribution-name'>Name for attribution:</label>

--- a/src/app/templates/upload.html
+++ b/src/app/templates/upload.html
@@ -36,14 +36,13 @@
         <input id='movie-file' type="file" onchange='check_upload_metadata()'>
         <span class="pure-form-message-inline">required</span>
       </div>
-      <div style='margin: 0.4em 0 0.4em 1em'>
+      <div style='margin: 0.4em 0 0.2em 1em'>
+        <small>Please review the <a href='tos#contributor-agreement' target='_blank'>Contributor Agreement</a> before answering.</small>
+      </div>
+      <div style='margin: 0.2em 0 0.4em 1em'>
         May this movie be used in academic research?
         <label style='margin-left:0.75em'><input type='radio' name='research_use' value='1' onchange='sync_attribution_ui()'> Yes</label>
         <label style='margin-left:0.5em'><input type='radio' name='research_use' value='0' onchange='sync_attribution_ui()'> No</label>
-      </div>
-      <div id='contributor-agreement-notice' style='display:none; margin: 0.2em 0 0.4em 1em'>
-        <small>By selecting Yes you agree to the
-          <a href='tos#contributor-agreement' target='_blank'>Contributor Agreement</a>.</small>
       </div>
       <div id='attribution-group' style='display:none; margin: 0.4em 0 0.4em 1em'>
         Would you like credit by name for the use of this video in research?

--- a/src/app/templates/upload.html
+++ b/src/app/templates/upload.html
@@ -51,7 +51,7 @@
       </div>
       <div class='pure-control-group' id='attribution-name-group' style='display:none'>
         <label for='attribution-name'>Name for attribution:</label>
-        <input type='text' id='attribution-name' name='attribution_name' placeholder='In the text' disabled>
+        <input type='text' id='attribution-name' name='attribution_name' value='{{user_name}}' disabled>
       </div>
       <div class='pure-control-group'>
         <label for='submit-button'>Click to upload:</label>

--- a/src/app/templates/upload.html
+++ b/src/app/templates/upload.html
@@ -36,23 +36,15 @@
         <input id='movie-file' type="file" onchange='check_upload_metadata()'>
         <span class="pure-form-message-inline">required</span>
       </div>
-      <div class='pure-control-group'>
-        <label>May this movie be used in academic research?</label>
-        <label class='pure-radio'>
-          <input type='radio' name='research_use' value='1' onchange='sync_attribution_ui()'> Yes
-        </label>
-        <label class='pure-radio'>
-          <input type='radio' name='research_use' value='0' onchange='sync_attribution_ui()'> No
-        </label>
+      <div style='margin: 0.4em 0 0.4em 1em'>
+        May this movie be used in academic research?
+        <label style='margin-left:0.75em'><input type='radio' name='research_use' value='1' onchange='sync_attribution_ui()'> Yes</label>
+        <label style='margin-left:0.5em'><input type='radio' name='research_use' value='0' onchange='sync_attribution_ui()'> No</label>
       </div>
-      <div class='pure-control-group' id='attribution-group' style='display:none'>
-        <label>Would you like credit by name for the use of this video in research?</label>
-        <label class='pure-radio'>
-          <input type='radio' name='credit_by_name' value='1' onchange='sync_attribution_ui()'> Yes
-        </label>
-        <label class='pure-radio'>
-          <input type='radio' name='credit_by_name' value='0' onchange='sync_attribution_ui()'> No (video used anonymously)
-        </label>
+      <div id='attribution-group' style='display:none; margin: 0.4em 0 0.4em 1em'>
+        Would you like credit by name for the use of this video in research?
+        <label style='margin-left:0.75em'><input type='radio' name='credit_by_name' value='1' onchange='sync_attribution_ui()'> Yes</label>
+        <label style='margin-left:0.5em'><input type='radio' name='credit_by_name' value='0' onchange='sync_attribution_ui()'> No (video used anonymously)</label>
       </div>
       <div class='pure-control-group' id='attribution-name-group' style='display:none'>
         <label for='attribution-name'>Name for attribution:</label>

--- a/tests/movie_test.py
+++ b/tests/movie_test.py
@@ -351,7 +351,12 @@ def test_new_movie_api(client, new_course):
 
 
 def test_new_movie_attribution_paths(client, new_course, local_s3):
-    """Test the three attribution paths: no research use, research anonymous, research with attribution."""
+    """Test the four attribution paths:
+    Path 0 — neither field submitted (not-answered)
+    Path 1 — explicitly no research use
+    Path 2 — research allowed but anonymously
+    Path 3 — research with named attribution
+    """
     cfg = copy.copy(new_course)
     api_key = cfg[API_KEY]
     with open(TEST_PLANTMOVIE_PATH, "rb") as f:
@@ -364,27 +369,44 @@ def test_new_movie_attribution_paths(client, new_course, local_s3):
         "movie_data_sha256": movie_data_sha256,
     }
 
-    # Path 1: May not be used in research (no research use)
-    resp1 = client.post("/api/new-movie", data={**base_data, "title": f"path1-{uuid.uuid4()}"})
+    # Path 0: Neither radio answered — research_use and credit_by_name absent from POST
+    resp0 = client.post("/api/new-movie", data={**base_data, "title": f"path0-{uuid.uuid4()}"})
+    res0 = resp0.get_json()
+    assert res0["error"] is False
+    movie_id0 = res0["movie_id"]
+    movie0 = odb.get_movie(movie_id=movie_id0)
+    assert movie0["research_use"] is None
+    assert movie0["credit_by_name"] is None
+    assert movie0.get("attribution_name") is None
+    pp0 = res0["presigned_post"]
+    assert pp0["fields"].get("x-amz-meta-research-use") == "not-answered"
+    assert pp0["fields"].get("x-amz-meta-credit-by-name") == "not-answered"
+    assert pp0["fields"].get("x-amz-meta-attribution-name") == ""
+    resp = client.post("/api/delete-movie", data={"api_key": api_key, "movie_id": movie_id0})
+    assert resp.get_json()["error"] is False
+    odb_movie_data.purge_movie(movie_id=movie_id0)
+
+    # Path 1: May not be used in research (research_use explicitly "0")
+    resp1 = client.post("/api/new-movie", data={**base_data, "title": f"path1-{uuid.uuid4()}", "research_use": "0"})
     res1 = resp1.get_json()
     assert res1["error"] is False
     movie_id1 = res1["movie_id"]
     movie1 = odb.get_movie(movie_id=movie_id1)
     assert movie1["research_use"] == 0
-    assert movie1["credit_by_name"] == 0
+    assert movie1["credit_by_name"] is None
     assert movie1.get("attribution_name") is None
     pp1 = res1["presigned_post"]
     assert pp1["fields"].get("x-amz-meta-research-use") == "0"
-    assert pp1["fields"].get("x-amz-meta-credit-by-name") == "0"
+    assert pp1["fields"].get("x-amz-meta-credit-by-name") == "not-answered"
     assert pp1["fields"].get("x-amz-meta-attribution-name") == ""
     resp = client.post("/api/delete-movie", data={"api_key": api_key, "movie_id": movie_id1})
     assert resp.get_json()["error"] is False
     odb_movie_data.purge_movie(movie_id=movie_id1)
 
-    # Path 2: May be used in research but anonymously
+    # Path 2: May be used in research but anonymously (credit_by_name explicitly "0")
     resp2 = client.post(
         "/api/new-movie",
-        data={**base_data, "title": f"path2-{uuid.uuid4()}", "research_use": "1"},
+        data={**base_data, "title": f"path2-{uuid.uuid4()}", "research_use": "1", "credit_by_name": "0"},
     )
     res2 = resp2.get_json()
     assert res2["error"] is False

--- a/tests/movie_test.py
+++ b/tests/movie_test.py
@@ -26,7 +26,7 @@ from app.constants import logger
 from .conftest import get_movie_bytes
 
 # Get constants from fixtures (fixtures themselves are in conftest.py)
-from .constants import TEST_PLANTMOVIE_PATH, MOVIE_TITLE
+from .constants import TEST_PLANTMOVIE_PATH, MOVIE_TITLE, ADMIN_EMAIL
 
 
 
@@ -448,6 +448,67 @@ def test_new_movie_attribution_paths(client, new_course, local_s3):
     resp = client.post("/api/delete-movie", data={"api_key": api_key, "movie_id": movie_id3})
     assert resp.get_json()["error"] is False
     odb_movie_data.purge_movie(movie_id=movie_id3)
+
+
+def test_set_research_metadata(client, new_course):
+    """Verify /api/set-research-metadata sets research_use, cascades to clear credit_by_name,
+    and blocks non-owners (including admins of other users' movies)."""
+    cfg = copy.copy(new_course)
+    api_key_user = cfg[API_KEY]
+
+    # Create a movie with research_use=1 and credit_by_name=1
+    with open(TEST_PLANTMOVIE_PATH, "rb") as f:
+        movie_data = f.read()
+    sha256 = s3_presigned.sha256_hash(movie_data)
+    resp = client.post("/api/new-movie", data={
+        "api_key": api_key_user,
+        "title": f"research-test-{uuid.uuid4()}",
+        "description": "test",
+        "movie_data_sha256": sha256,
+        "research_use": "1",
+        "credit_by_name": "1",
+    })
+    res = resp.get_json()
+    assert res["error"] is False
+    movie_id = res["movie_id"]
+
+    # Owner sets research_use to 0 — credit_by_name should be cleared
+    r = client.post("/api/set-research-metadata", data={
+        "api_key": api_key_user, "movie_id": movie_id, "research_use": "0",
+    })
+    assert r.get_json()["error"] is False
+    m = odb.get_movie(movie_id=movie_id)
+    assert m["research_use"] == 0
+    assert m.get("credit_by_name") is None  # cascade cleared
+
+    # Owner sets research_use=1 and credit_by_name=1 together
+    r = client.post("/api/set-research-metadata", data={
+        "api_key": api_key_user, "movie_id": movie_id,
+        "research_use": "1", "credit_by_name": "1",
+    })
+    assert r.get_json()["error"] is False
+    m = odb.get_movie(movie_id=movie_id)
+    assert m["research_use"] == 1
+    assert m["credit_by_name"] == 1
+
+    # Owner sets research_use to N/A (omitted) — credit_by_name should be cleared
+    r = client.post("/api/set-research-metadata", data={
+        "api_key": api_key_user, "movie_id": movie_id,
+    })
+    assert r.get_json()["error"] is False
+    m = odb.get_movie(movie_id=movie_id)
+    assert m.get("research_use") is None
+    assert m.get("credit_by_name") is None
+
+    # Non-owner (admin of the course) cannot change research metadata
+    admin_api_key = odb.make_new_api_key(email=cfg[ADMIN_EMAIL])
+    r = client.post("/api/set-research-metadata", data={
+        "api_key": admin_api_key, "movie_id": movie_id, "research_use": "1",
+    })
+    assert r.get_json()["error"] is True
+
+    odb_movie_data.purge_movie(movie_id=movie_id)
+    odb_movie_data.delete_movie(movie_id=movie_id)
 
 
 def test_api_edit_movie(new_movie, client):


### PR DESCRIPTION
## Summary

- **#954** Replace research use/credit checkboxes with Yes/No radio buttons and a three-state model (`1`=Yes, `0`=No, `None`=not answered). Schema, API, S3 metadata, and JS all updated. `'not-answered'` sentinel used in S3/MP4 metadata for the None state.
- **#994** Add a Contributor Agreement section to the TOS page (non-exclusive research license, optional credit by name). Upload form links to it before the radio buttons so users can review it before answering.
- **#996** Add *research use* and *credit* columns to the movie list. Uploaders get Yes/No dropdowns (N/A shown as a non-selectable `—` placeholder); admins and other viewers see read-only text. Changing research use away from Yes cascade-clears credit server-side via new `/api/set-research-metadata` endpoint (owner-only).
- **#997** Pre-populate the attribution name field with the user's display name.
- Docs updated: `FlaskAPI.md`, `UserTutorial.rst`, `DynamoDB.rst`, `MOVIE_METADATA.rst`.

## Test plan

- [x] Upload a movie — verify radio buttons appear with Contributor Agreement link above them, attribution name pre-filled
- [x] Select Yes for research use → credit radio group appears; select Yes for credit → name field enabled
- [x] Select No for research use → credit group hidden; select No → name field stays pre-filled
- [ ] Leave both unanswered → upload succeeds with `research_use=None`, `credit_by_name=None` in DB; S3 metadata shows `not-answered`
- [x] On /list, verify Research Use and Credit columns appear for all movie tables
- [x] As uploader: change research use to Yes → credit dropdown becomes active; change to No → credit shows N/A
- [x] As uploader: N/A state shows `—` placeholder that cannot be re-selected
- [x] As course admin viewing another user's movie: columns are read-only text
- [ ] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)