### PR TITLE
Sortable movie table columns via DataTables (#1004)

### DIFF
--- a/jstests/list_movies.test.js
+++ b/jstests/list_movies.test.js
@@ -8,6 +8,8 @@ const path = require('path');
 
 const module = require('planttracer');
 const list_movies_data = module.list_movies_data;
+const play_clicked = module.play_clicked;
+const hide_clicked = module.hide_clicked;
 const dtInstances = module.dtInstances;
 
 global.Audio = function() {
@@ -254,5 +256,234 @@ describe('list_movies_data', () => {
 
     const publishedHtml = mockElements['#your-published-movies'].innerHTML;
     expect(publishedHtml).toContain('Status: <b>Published</b>');
+  });
+});
+
+describe('play_clicked', () => {
+  let mockChildApi;
+  let mockRow;
+  let mockDtInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.api_key = 'test-api-key';
+    global.LAMBDA_API_BASE = 'https://lambda.example.com/';
+
+    // Build a minimal DataTables child-row mock
+    mockChildApi = { show: jest.fn() };
+    mockRow = {
+      child: jest.fn(() => mockChildApi),
+    };
+    mockDtInstance = {
+      destroy: jest.fn(),
+      row: jest.fn(() => mockRow),
+    };
+
+    // Pre-populate dtInstances so play_clicked can find the table
+    dtInstances['#your-published-movies'] = mockDtInstance;
+
+    // Minimal closest() on the button element
+    document.querySelector = jest.fn(() => null);
+  });
+
+  afterEach(() => {
+    delete dtInstances['#your-published-movies'];
+  });
+
+  test('returns early when LAMBDA_API_BASE is not set', () => {
+    global.LAMBDA_API_BASE = '';
+    const btn = {
+      getAttribute: jest.fn((attr) => {
+        if (attr === 'x-movie_id') return '1';
+        if (attr === 'x-rowid') return 'row1';
+        if (attr === 'x-div-selector') return '#your-published-movies';
+        return null;
+      }),
+      closest: jest.fn(() => null),
+    };
+    play_clicked(btn);
+    expect(mockDtInstance.row).not.toHaveBeenCalled();
+  });
+
+  test('returns early when dtInstances entry is missing', () => {
+    delete dtInstances['#your-published-movies'];
+    const btn = {
+      getAttribute: jest.fn((attr) => {
+        if (attr === 'x-movie_id') return '1';
+        if (attr === 'x-rowid') return 'row1';
+        if (attr === 'x-div-selector') return '#your-published-movies';
+        return null;
+      }),
+      closest: jest.fn(() => null),
+    };
+    play_clicked(btn);
+    expect(mockDtInstance.row).not.toHaveBeenCalled();
+  });
+
+  test('shows loading child row and fetches movie data on success', async () => {
+    const mockTr = document.createElement('tr');
+    const btn = {
+      getAttribute: jest.fn((attr) => {
+        if (attr === 'x-movie_id') return '42';
+        if (attr === 'x-rowid') return 'row42';
+        if (attr === 'x-div-selector') return '#your-published-movies';
+        return null;
+      }),
+      closest: jest.fn(() => mockTr),
+    };
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ url: 'https://s3.example.com/movie.mp4' }),
+      })
+    );
+
+    play_clicked(btn);
+
+    // Loading child row shown immediately (synchronously)
+    expect(mockDtInstance.row).toHaveBeenCalledWith(mockTr);
+    expect(mockRow.child).toHaveBeenCalledWith(expect.stringContaining('Loading'));
+    expect(mockChildApi.show).toHaveBeenCalled();
+
+    // Allow the fetch chain to resolve
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Video child row shown after fetch resolves
+    expect(mockRow.child).toHaveBeenCalledWith(expect.stringContaining('video'));
+  });
+
+  test('shows error child row when fetch returns non-ok response', async () => {
+    const mockTr = document.createElement('tr');
+    const btn = {
+      getAttribute: jest.fn((attr) => {
+        if (attr === 'x-movie_id') return '42';
+        if (attr === 'x-rowid') return 'row42';
+        if (attr === 'x-div-selector') return '#your-published-movies';
+        return null;
+      }),
+      closest: jest.fn(() => mockTr),
+    };
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ message: 'Forbidden' }),
+      })
+    );
+
+    play_clicked(btn);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockRow.child).toHaveBeenLastCalledWith(expect.stringContaining('error'));
+  });
+
+  test('shows error child row when fetch rejects', async () => {
+    const mockTr = document.createElement('tr');
+    const btn = {
+      getAttribute: jest.fn((attr) => {
+        if (attr === 'x-movie_id') return '42';
+        if (attr === 'x-rowid') return 'row42';
+        if (attr === 'x-div-selector') return '#your-published-movies';
+        return null;
+      }),
+      closest: jest.fn(() => mockTr),
+    };
+
+    global.fetch = jest.fn(() => Promise.reject(new Error('Network error')));
+
+    play_clicked(btn);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockRow.child).toHaveBeenLastCalledWith(expect.stringContaining('error'));
+  });
+});
+
+describe('hide_clicked', () => {
+  let mockChildApi;
+  let mockRow;
+  let mockDtInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockChildApi = { show: jest.fn() };
+    mockRow = { child: jest.fn(() => mockChildApi) };
+    mockDtInstance = {
+      destroy: jest.fn(),
+      row: jest.fn(() => mockRow),
+    };
+    dtInstances['#your-published-movies'] = mockDtInstance;
+  });
+
+  afterEach(() => {
+    delete dtInstances['#your-published-movies'];
+  });
+
+  test('pauses video and collapses child row', () => {
+    // Insert a fake video element into the document
+    const video = document.createElement('video');
+    video.id = 'video-row99';
+    video.pause = jest.fn();
+    document.body.appendChild(video);
+
+    const parentTr = document.createElement('tr');
+    const childTr = document.createElement('tr');
+    parentTr.appendChild(childTr); // childTr.previousElementSibling === parentTr siblings...
+    // DOM: parentTr → childTr as siblings inside a tbody
+    const tbody = document.createElement('tbody');
+    tbody.appendChild(parentTr);
+    tbody.appendChild(childTr);
+
+    const btn = {
+      getAttribute: jest.fn((attr) => {
+        if (attr === 'x-rowid') return 'row99';
+        if (attr === 'x-div-selector') return '#your-published-movies';
+        return null;
+      }),
+      closest: jest.fn(() => childTr),
+    };
+
+    hide_clicked(btn);
+
+    expect(video.pause).toHaveBeenCalled();
+    expect(mockDtInstance.row).toHaveBeenCalledWith(parentTr);
+    expect(mockRow.child).toHaveBeenCalledWith(false);
+
+    document.body.removeChild(video);
+  });
+
+  test('handles missing video element gracefully', () => {
+    const parentTr = document.createElement('tr');
+    const childTr = document.createElement('tr');
+    const tbody = document.createElement('tbody');
+    tbody.appendChild(parentTr);
+    tbody.appendChild(childTr);
+
+    const btn = {
+      getAttribute: jest.fn((attr) => {
+        if (attr === 'x-rowid') return 'nonexistent';
+        if (attr === 'x-div-selector') return '#your-published-movies';
+        return null;
+      }),
+      closest: jest.fn(() => childTr),
+    };
+
+    expect(() => hide_clicked(btn)).not.toThrow();
+    expect(mockDtInstance.row).toHaveBeenCalledWith(parentTr);
+  });
+
+  test('handles missing dtInstances entry gracefully', () => {
+    delete dtInstances['#your-published-movies'];
+    const btn = {
+      getAttribute: jest.fn((attr) => {
+        if (attr === 'x-rowid') return 'row99';
+        if (attr === 'x-div-selector') return '#your-published-movies';
+        return null;
+      }),
+      closest: jest.fn(() => null),
+    };
+    expect(() => hide_clicked(btn)).not.toThrow();
   });
 });

--- a/jstests/list_movies.test.js
+++ b/jstests/list_movies.test.js
@@ -84,7 +84,7 @@ describe('list_movies_data', () => {
 
     // Check that the published movies div was populated
     const publishedHtml = mockElements['#your-published-movies'].innerHTML;
-    expect(publishedHtml).toContain("<table>");
+    expect(publishedHtml).toContain("pure-table");
     expect(publishedHtml).toContain("Movie Title");
   });
 
@@ -125,7 +125,7 @@ describe('list_movies_data', () => {
 
     // Check that course movies are shown in the right section
     const courseHtml = mockElements['#course-movies'].innerHTML;
-    expect(courseHtml).toContain('<table>');
+    expect(courseHtml).toContain('pure-table');
   });
 
   test('should display a link to upload movies for non-demo users', () => {

--- a/jstests/list_movies.test.js
+++ b/jstests/list_movies.test.js
@@ -8,6 +8,7 @@ const path = require('path');
 
 const module = require('planttracer');
 const list_movies_data = module.list_movies_data;
+const dtInstances = module.dtInstances;
 
 global.Audio = function() {
   this.play = jest.fn();
@@ -38,6 +39,14 @@ describe('list_movies_data', () => {
     global.TABLE_HEAD = globalData.TABLE_HEAD;
     global.user_primary_course_id = parseInt(globalData.user_primary_course_id, 10);
 
+    // Mock DataTables so planttracer.js can call $.fn.DataTable() without a real browser
+    const mockDtInstance = {
+      destroy: jest.fn(),
+      row: jest.fn(),
+    };
+    $.fn.DataTable = jest.fn(() => mockDtInstance);
+    $.fn.DataTable.isDataTable = jest.fn(() => false);
+
     // Mock document.querySelector to return mock elements with innerHTML setter
     mockElements = {};
     document.querySelector = jest.fn((selector) => {
@@ -47,7 +56,7 @@ describe('list_movies_data', () => {
       return mockElements[selector];
     });
 
-    // Mock document.querySelectorAll for hiding movie players
+    // Mock document.querySelectorAll (kept for safety; no longer called by movies code)
     document.querySelectorAll = jest.fn(() => []);
   });
 
@@ -140,6 +149,59 @@ describe('list_movies_data', () => {
 
     const publishedHtml = mockElements['#your-published-movies'].innerHTML;
     expect(publishedHtml).not.toContain('Click here to upload a movie');
+  });
+
+  // DataTables initialisation tests
+
+  test('should initialise DataTables when movies are present', () => {
+    const movies = [
+      {
+        movie_id: 1,
+        user_id: 1,
+        published: 1,
+        title: 'Movie Title',
+        description: 'Description',
+        date_uploaded: 1627689600,
+        deleted: 0,
+        orig_movie: false,
+      }
+    ];
+
+    list_movies_data(movies);
+    // DataTable() should have been called at least once (for the published table)
+    expect($.fn.DataTable).toHaveBeenCalled();
+    // The DataTables config should disable sorting on column 5 (status and action)
+    const dtConfig = $.fn.DataTable.mock.calls[0][0];
+    expect(dtConfig.columnDefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ orderable: false, targets: 5 })
+      ])
+    );
+    // Default sort should be column 1 (uploaded), descending
+    expect(dtConfig.order).toEqual([[1, 'desc']]);
+  });
+
+  test('should not initialise DataTables when the movie list is empty', () => {
+    list_movies_data([]);
+    expect($.fn.DataTable).not.toHaveBeenCalled();
+  });
+
+  test('should store DataTables instance in dtInstances keyed by divSelector', () => {
+    const movies = [
+      {
+        movie_id: 1,
+        user_id: 1,
+        published: 1,
+        title: 'Movie Title',
+        description: 'Description',
+        date_uploaded: 1627689600,
+        deleted: 0,
+        orig_movie: false,
+      }
+    ];
+
+    list_movies_data(movies);
+    expect(dtInstances['#your-published-movies']).toBeDefined();
   });
 
   // Action Button Tests

--- a/package.json
+++ b/package.json
@@ -53,6 +53,14 @@
     },
     "testMatch": [
       "**/?(*.)+(spec|test).(mjs|js)"
-    ]
+    ],
+    "coverageThreshold": {
+      "global": {
+        "statements": 68,
+        "branches": 62,
+        "functions": 62,
+        "lines": 69
+      }
+    }
   }
 }

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -709,7 +709,7 @@ function list_movies_data( movies ) {
   // This fills in the given table with a given list
   function movies_fill_div( divSelector, which, mlist) {
     // Top of table
-    let h = "<table>";
+    let h = "<table class='pure-table pure-table-horizontal pure-table-striped'>";
     if (mlist.length > 0 ){
       h += "<thead>" + TABLE_HEAD + "</thead>";
     }

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -884,13 +884,12 @@ function list_movies_data( movies ) {
       h += '<tr><td><i>No movies</i></td></tr>';
     }
 
-    // Offer to upload movies if not in demo mode.
-    if (!demo_mode) {
-      h += '<tr><td colspan="8"><a href="/upload">Click here to upload a movie</a></td></tr>';
-    }
-
     h += "</tbody>";
     h += "</table>";
+    // Offer to upload movies if not in demo mode (outside the table so DataTables doesn't count it).
+    if (!demo_mode) {
+      h += '<p><a href="/upload">Click here to upload a movie</a></p>';
+    }
     const divElement = document.querySelector(divSelector);
     if (divElement) {
       divElement.innerHTML = h;

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -471,17 +471,21 @@ function upload_ready_function() {
 function play_clicked( e ) {
   const movie_id = e.getAttribute('x-movie_id');
   const rowid = e.getAttribute('x-rowid');
+  const divSelector = e.getAttribute('x-div-selector');
   const base = (typeof LAMBDA_API_BASE !== 'undefined' && LAMBDA_API_BASE) ? LAMBDA_API_BASE.replace(/\/$/, '') : '';
   if (!base) {
+    return;
+  }
+  const dt = divSelector ? dtInstances[divSelector] : null;
+  if (!dt) {
     return;
   }
   // ask the movie-data service for JSON information about the movie,
   // which will be a signed S3 GET URL
   const apiUrl = `${base}/api/v1/movie-data?api_key=${api_key}&movie_id=${movie_id}&format=json`;
-  $(`#tr-${rowid}`).show();
-  const td = $(`#td-${rowid}`);
-  td.html('<span class="loading">Loading…</span>');
-  td.show();
+  const tr = e.closest('tr');
+  const row = dt.row(tr);
+  row.child('<td colspan="8"><span class="loading">Loading…</span></td>').show();
 
   fetch(apiUrl)
     .then(function (resp) {
@@ -500,26 +504,37 @@ function play_clicked( e ) {
       if (!url) {
         throw new Error('No URL in response');
       }
-      td.html('');
-      td.html(`<video class='movie_player' id='video-${rowid}' controls playsinline><source src='${url}' type='video/mp4'></video>` +
-              `<input class='hide' x-movie_id='${movie_id}' x-rowid='${rowid}' type='button' value='hide' onclick='hide_clicked(this)'>`);
-      td.show();
-      const video = $(`#video-${rowid}`);
-      const videoEl = video.get(0);
+      row.child(
+        `<td colspan="8"><video class='movie_player' id='video-${rowid}' controls playsinline>` +
+        `<source src='${url}' type='video/mp4'></video>` +
+        `<input class='hide' x-movie_id='${movie_id}' x-rowid='${rowid}' x-div-selector='${divSelector}' ` +
+        `type='button' value='hide' onclick='hide_clicked(this)'></td>`
+      ).show();
+      const videoEl = document.getElementById(`video-${rowid}`);
       if (videoEl) {
         videoEl.play();
       }
     })
     .catch(function (err) {
-      td.html('<span class="error">' + (err.message || 'Playback failed') + '</span>');
+      row.child('<td colspan="8"><span class="error">' + (err.message || 'Playback failed') + '</span></td>').show();
     });
 }
 
 function hide_clicked( e ) {
-  let rowid = e.getAttribute('x-rowid');
-  $(`#video-${rowid}`).hide();
-  $(`#tr-${rowid}`).hide();
-  $(`#td-${rowid}`).hide();
+  const rowid = e.getAttribute('x-rowid');
+  const divSelector = e.getAttribute('x-div-selector');
+  const videoEl = document.getElementById(`video-${rowid}`);
+  if (videoEl) {
+    videoEl.pause();
+  }
+  const dt = divSelector ? dtInstances[divSelector] : null;
+  if (dt) {
+    const childTr = e.closest('tr');
+    const parentTr = childTr ? childTr.previousElementSibling : null;
+    if (parentTr) {
+      dt.row(parentTr).child(false);
+    }
+  }
 }
 
 function analyze_clicked( e ) {
@@ -677,6 +692,9 @@ function action_button_clicked( e ) {
 //                           #1          #2               #3               #4              #5                 #6                #7              #8            #9
 const TABLE_HEAD = "<tr> <th>user</th>  <th>uploaded</th> <th>title</th> <th>description</th> <th>size</th> <th>status and action</th> <th>research use</th> <th>credit</th> </tr>";
 
+// DataTables instances keyed by divSelector — used by play_clicked / hide_clicked
+const dtInstances = {};
+
 // Phase 3: list shows movie status. Eventually this list should be server-rendered (Jinja2).
 function list_movies_data( movies ) {
   const PUBLISHED = 'published';
@@ -737,18 +755,19 @@ function list_movies_data( movies ) {
       function make_td_tristate(property, value, disabled) {
         tid += 1;
         const label = tristate_label(value);
+        const sortVal = value === 1 ? 1 : value === 0 ? 0 : -1;
         if (m.user_id === user_id && !demo_mode && !disabled) {
           const sel1 = value === 1 ? 'selected' : '';
           const sel0 = value === 0 ? 'selected' : '';
           const placeholder = (value !== 1 && value !== 0)
             ? `<option value='' disabled selected>—</option>` : '';
-          return `<td><select id='${tid}' x-movie_id='${movie_id}' x-property='${property}' onchange='research_metadata_changed(this)'>` +
+          return `<td data-order='${sortVal}'><select id='${tid}' x-movie_id='${movie_id}' x-property='${property}' onchange='research_metadata_changed(this)'>` +
             placeholder +
             `<option value='1' ${sel1}>Yes</option>` +
             `<option value='0' ${sel0}>No</option>` +
             `</select></td>\n`;
         }
-        return `<td>${label}</td>\n`;
+        return `<td data-order='${sortVal}'>${label}</td>\n`;
       }
 
       function _make_td_checkbox(property, value) {
@@ -787,11 +806,11 @@ function list_movies_data( movies ) {
       const dateSec = m.date_uploaded && Number(m.date_uploaded);
       const movieDate = dateSec ? new Date(dateSec * 1000) : null;
       const up_down   = movieDate ? movieDate.toLocaleString().replace(' ','<br>').replace(',','') : '—';
-      const play      = `<input class='play'    x-rowid='${rowid}' x-movie_id='${movie_id}' type='button' value='${PLAY_LABEL}' onclick='play_clicked(this)'>`;
+      const play      = `<input class='play'    x-rowid='${rowid}' x-movie_id='${movie_id}' x-div-selector='${divSelector}' type='button' value='${PLAY_LABEL}' onclick='play_clicked(this)'>`;
       let playt = '';
       let analyze_label = 'analyze';
       if (m.tracked_movie_id){
-        playt     = `<input class='play'    x-rowid='${rowid}' x-movie_id='${m.tracked_movie_id}' type='button' value='${PLAY_TRACKED_LABEL}' onclick='play_clicked(this)'>`;
+        playt     = `<input class='play'    x-rowid='${rowid}' x-movie_id='${m.tracked_movie_id}' x-div-selector='${divSelector}' type='button' value='${PLAY_TRACKED_LABEL}' onclick='play_clicked(this)'>`;
         analyze_label = 're-analyze';
       }
       const analyze   = m.orig_movie ? '' : `<input class='analyze' x-rowid='${rowid}' x-movie_id='${movie_id}' type='button' value='${analyze_label}' onclick='analyze_clicked(this)'>`;
@@ -803,9 +822,9 @@ function list_movies_data( movies ) {
       const framesStr = (m.total_frames != null) ? m.total_frames : '—';
 
       let rows = `<tr class='${you_class}'>` +
-          `<td class='${you_class}'> ${m.user_name} </td> <td> ${up_down} </td>` + // #1, #2, #3
+          `<td class='${you_class}'> ${m.user_name} </td> <td data-order='${dateSec || 0}'> ${up_down} </td>` + // #1, #2, #3
           make_td_text( "title", m.title, "<br/>" + play + playt + analyze ) + make_td_text( "description", m.description, '') + // #4 #5
-          `<td> frame: ${frameStr} Kbytes: ${kbytesStr} ` +
+          `<td data-order='${m.total_bytes || 0}'> frame: ${frameStr} Kbytes: ${kbytesStr} ` +
           `<br> fps: ${fpsStr} frames: ${framesStr} </td> `;  // #6
 
       rows += "<td> Status: "; // #7
@@ -854,11 +873,6 @@ function list_movies_data( movies ) {
       rows += make_td_tristate('credit_by_name', creditDisabled ? null : m.credit_by_name, creditDisabled);
 
       rows += "</tr>\n";
-
-      // Now make the player row
-      rows += `<tr    class='movie_player' id='tr-${rowid}'> `+
-        `<td    class='movie_player' id='td-${rowid}' colspan='8' ></td>` +
-        `</tr>\n`;
       return rows;
     }
 
@@ -880,6 +894,23 @@ function list_movies_data( movies ) {
     const divElement = document.querySelector(divSelector);
     if (divElement) {
       divElement.innerHTML = h;
+      // Initialize DataTables for column sorting (only when there are rows to sort)
+      if ($.fn && $.fn.DataTable && mlist.length > 0) {
+        const tableEl = $(`${divSelector} table`);
+        if ($.fn.DataTable.isDataTable(tableEl)) {
+          tableEl.DataTable().destroy();
+        }
+        dtInstances[divSelector] = tableEl.DataTable({
+          paging: false,
+          searching: false,
+          info: false,
+          order: [[1, 'desc']],       // default: uploaded column, newest first
+          columnDefs: [
+            { orderable: false, targets: 5 },            // status and action — not sortable
+            { type: 'num', targets: [1, 4, 6, 7] }      // numeric sort for these columns
+          ]
+        });
+      }
     }
   }
   // Sort newest-first by date_uploaded (movies with no date sort to the end)
@@ -894,7 +925,6 @@ function list_movies_data( movies ) {
                    COURSE, movies.filter( m => (m.course_id==user_primary_course_id && (demo_mode || (m.user_id!=user_id)) && !m.orig_movie && (m.published==1 || admin))).sort(byNewest));
   movies_fill_div( '#your-deleted-movies',
                    DELETED, movies.filter( m => (m.user_id==user_id && m.published==0 && m.deleted==1 && !m.orig_movie)).sort(byNewest));
-  document.querySelectorAll('.movie_player').forEach(el => el.style.display = 'none');
 }
 
 // Gets the list from the server of every movie we can view and displays it in the HTML element
@@ -1024,6 +1054,7 @@ if (typeof module != 'undefined'){
     checkLambdaStatus,
     check_upload_metadata,
     computeSHA256,
+    dtInstances,
     first_frame_url,
     list_movies_data,
     list_users,

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -1061,6 +1061,8 @@ if (typeof module != 'undefined'){
     purge_movie,
     register_func,
     resend_func,
+    hide_clicked,
+    play_clicked,
     research_metadata_changed,
     row_checkbox_clicked,
     set_property,

--- a/src/app/templates/list.html
+++ b/src/app/templates/list.html
@@ -17,7 +17,7 @@
   /* DataTables sort-direction indicators (replaces the DataTables stylesheet) */
   table.dataTable thead th.sorting,
   table.dataTable thead th.sorting_asc,
-  table.dataTable thead th.sorting_desc { cursor: pointer; }
+  table.dataTable thead th.sorting_desc { cursor: pointer; white-space: nowrap; }
   table.dataTable thead th.sorting::after      { content: " \21D5"; opacity: 0.4; }
   table.dataTable thead th.sorting_asc::after  { content: " \2191"; }
   table.dataTable thead th.sorting_desc::after { content: " \2193"; }

--- a/src/app/templates/list.html
+++ b/src/app/templates/list.html
@@ -2,7 +2,6 @@
 {% extends 'base.html' %}
 
 {% block head %}
-<link rel="stylesheet" href="https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css">
 <script src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js"></script>
 {% endblock %}
 
@@ -10,39 +9,27 @@
 <div id='load_message'><b>{{load_message}}</b></div>
 
 <style>
-  tr.you {
-  color: blue;
+  /* Highlight the logged-in user's own movies */
+  tr.you td {
+    color: blue;
   }
 
-  div.mtable table {
-  border:1px solid black;
-  border-collapse:collapse;
-  }
-
-  div.mtable input[type=checkbox] {
-  color:black;
-  background-color: yellow;
-  padding: 3px;
-  }
-
-  /* table headers for the movie tables. */
-  div.mtable th {
-  }
-
-  div.mtable td {
-  border:1px solid blue;
-  padding: 3px;
-  }
+  /* DataTables sort-direction indicators (replaces the DataTables stylesheet) */
+  table.dataTable thead th.sorting,
+  table.dataTable thead th.sorting_asc,
+  table.dataTable thead th.sorting_desc { cursor: pointer; }
+  table.dataTable thead th.sorting::after      { content: " \21D5"; opacity: 0.4; }
+  table.dataTable thead th.sorting_asc::after  { content: " \2191"; }
+  table.dataTable thead th.sorting_desc::after { content: " \2193"; }
 
   div.mtable td.check {
-  text-align:center;
+    text-align: center;
   }
 
   input[type=checkbox] {
-  width: 20px;
-  height: 20px;
+    width: 20px;
+    height: 20px;
   }
-
 </style>
 
 <div class='demo'>

--- a/src/app/templates/list.html
+++ b/src/app/templates/list.html
@@ -14,13 +14,26 @@
     color: blue;
   }
 
-  /* DataTables sort-direction indicators (replaces the DataTables stylesheet) */
+  /* DataTables sort-direction indicators (replaces the DataTables stylesheet).
+     Use position:absolute so the arrow never wraps regardless of column width. */
   table.dataTable thead th.sorting,
   table.dataTable thead th.sorting_asc,
-  table.dataTable thead th.sorting_desc { cursor: pointer; white-space: nowrap; }
-  table.dataTable thead th.sorting::after      { content: " \21D5"; opacity: 0.4; }
-  table.dataTable thead th.sorting_asc::after  { content: " \2191"; }
-  table.dataTable thead th.sorting_desc::after { content: " \2193"; }
+  table.dataTable thead th.sorting_desc {
+    cursor: pointer;
+    position: relative;
+    padding-right: 1.4em;   /* reserve space for the arrow */
+  }
+  table.dataTable thead th.sorting::after,
+  table.dataTable thead th.sorting_asc::after,
+  table.dataTable thead th.sorting_desc::after {
+    position: absolute;
+    right: 0.3em;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+  table.dataTable thead th.sorting::after      { content: "\21D5"; opacity: 0.4; }
+  table.dataTable thead th.sorting_asc::after  { content: "\2191"; }
+  table.dataTable thead th.sorting_desc::after { content: "\2193"; }
 
   div.mtable td.check {
     text-align: center;

--- a/src/app/templates/list.html
+++ b/src/app/templates/list.html
@@ -1,6 +1,10 @@
 <!-- -*- mode: html -*- -->
 {% extends 'base.html' %}
 
+{% block head %}
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css">
+<script src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js"></script>
+{% endblock %}
 
 {% block body %}
 <div id='load_message'><b>{{load_message}}</b></div>


### PR DESCRIPTION
## Summary

- Loads [DataTables 1.13.8](https://datatables.net/) (MIT, jQuery plugin) via CDN in `list.html` — no install required, consistent with how Pure CSS and fonts are already loaded
- Replaces the static hidden player `<tr>` with a DataTables **child row**, shown/hidden via `row.child().show()` / `row.child(false)` — keeps the player paired with its data row through any sort
- All columns are sortable except **status and action** (`orderable: false`); default sort is **uploaded ↓** (newest first), preserving the #909 behaviour
- `data-order` attributes on uploaded, size, research-use, and credit cells ensure numeric sort on those columns
- Movie tables are restyled to match the Marker table on the Analyze page (`pure-table pure-table-horizontal pure-table-striped`)
- Sort arrows use `position: absolute` inside a `position: relative` `<th>` so they never wrap onto a second line regardless of column width
- "Click here to upload" link moved from `<tbody>` to a `<p>` below the table (a `colspan` row in tbody triggered DataTables tn/18)

## Test plan
- [ ] Movies page loads without DataTables warning modal
- [ ] Clicking any column header sorts that table; clicking again reverses direction
- [ ] **status and action** column header is not clickable
- [ ] Default order on page load is newest-first (uploaded ↓)
- [ ] Each of the four tables (published, unpublished, course, deleted) sorts independently
- [ ] Play button opens the inline video player; Hide closes it and pauses the video
- [ ] Table appearance matches the Marker table on the Analyze page
- [ ] `make check` passes (lint + pytest + jscoverage)

fixes #1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)