### PR TITLE
Document version bump as required PR step before tagging (#1014)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,22 +195,26 @@ Each line in the release notes should be a Markdown link to the issue/PR, e.g.:
 
 ## Tagging a Release
 
-Version tagging is done directly on `main` (not via a PR). Once all PRs for the milestone are merged:
+Before tagging, the version number **must** be updated via a normal feature branch + PR and merged to `main`. Once the version bump PR is merged:
 
-1. **Create a GitHub Issue** for the tag (so the tag commit references an issue, per project convention):
+1. **Bump the version number** (via feature branch + PR, merged before tagging). Update exactly these two files:
+   - `src/app/constants.py` — `__version__ = 'X.Y.Z'`
+   - `pyproject.toml` — `version = "X.Y.Z"`
+
+2. **Create a GitHub Issue** for the tag (so the tag references an issue, per project convention):
    ```bash
    gh issue create --title "Tag main branch as <tag-name>" \
      --body "All PRs for <milestone> merged. Tag main with \`<tag-name>\`." \
      --milestone "<milestone-name>"
    ```
 
-2. **Tag and push** (always use an annotated tag so the tag carries a message referencing the issue):
+3. **Tag and push** the already-bumped main (always use an annotated tag):
    ```bash
    git tag -a <tag-name> -m "refs #<issue-number>: tag main as <tag-name>"
    git push origin <tag-name>
    ```
 
-3. **Close the issue** referencing the tag:
+4. **Close the issue** referencing the tag:
    ```bash
    gh issue close <issue-number> --comment "Tagged as \`<tag-name>\`."
    ```

--- a/docs/Development/ReleaseProcess.rst
+++ b/docs/Development/ReleaseProcess.rst
@@ -22,12 +22,14 @@ Ensure all Issues and PRs intended for this release are merged to ``main`` and C
 Step 2 — Bump the Version Number
 ---------------------------------
 
-The version number must be updated before tagging. Update it in **two files** (do not update ``lambda-resize``; its version is generated):
+The version number **must** be updated via a normal feature branch + PR and merged to ``main`` before the tag is created (Step 4). Do not skip this step — two releases shipped with a stale version number because it was omitted.
+
+Update exactly **two files** (do not update ``lambda-resize``; its version is generated automatically):
 
 - ``pyproject.toml`` — ``version = "X.Y.Z"``
 - ``src/app/constants.py`` — ``__version__ = 'X.Y.Z'``
 
-Open a PR for this change, referencing an Issue. Merge to ``main`` before proceeding.
+Create an Issue for the bump, branch off ``main``, commit the changes referencing the issue, open a PR, and merge it before proceeding to Step 4.
 
 Step 3 — Prepare the GitHub Milestone
 --------------------------------------
@@ -81,10 +83,10 @@ Version tagging is done directly on ``main`` (not via a PR).
      --body "All PRs for Version-X.Y.Z merged. Tag main with \`ver-X.Y.Z\`." \
      --milestone "Version-X.Y.Z"
 
-   # 2. Switch to main and pull
+   # 2. Switch to main and pull (version bump PR must already be merged)
    git checkout main && git pull
 
-   # 3. Create an annotated tag (always use -a so the tag carries a message)
+   # 3. Create an annotated tag on the already-bumped main (always use -a)
    git tag -a ver-X.Y.Z -m "refs #<issue-number>: tag main as ver-X.Y.Z"
    git push origin ver-X.Y.Z
 


### PR DESCRIPTION
## Summary

- Clarifies in `CLAUDE.md` that the version number must be bumped via a feature branch + PR merged to `main` *before* the release tag is created
- Updates `docs/Development/ReleaseProcess.rst` with the same clarification, and adds a note that two releases shipped with a stale version number because this step was omitted
- Reorders the tagging steps in `CLAUDE.md` so the version bump is listed first, before the tagging Issue

## Test plan
- [x] `poetry run sphinx-build -W --keep-going -b html docs docs/_build/html` builds with no warnings

fixes #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)