### PR TITLE
Bump version to 0.9.7.6.1 (#1016)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "webapp"
-version = "0.9.7.5.1"
+version = "0.9.7.6.1"
 description = "PlantTracer webapp"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/src/app/constants.py
+++ b/src/app/constants.py
@@ -7,7 +7,7 @@ Constants are created in classes so we can import the class and don't have to im
 import logging
 import os
 
-__version__ = '0.9.7.5.1'
+__version__ = '0.9.7.6.1'
 
 # these aren't strictly constants...
 log_level = os.getenv("LOG_LEVEL","INFO").upper()


### PR DESCRIPTION
## Summary

- Bumps `src/app/constants.py` and `pyproject.toml` from `0.9.7.5.1` to `0.9.7.6.1` in preparation for the `ver-0.9.7.6.1` release.

fixes #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)