### PR TITLE
Fix Download Trackpoints and canvas zoom after tracing (#918, #1019, #1020)

### DIFF
--- a/docs/Development/FlaskAPI.md
+++ b/docs/Development/FlaskAPI.md
@@ -251,7 +251,7 @@ Download all trackpoints for a movie as CSV (default) or JSON.
 | `movie_id` | Yes | |
 | `format` | No | `"json"` for JSON; omit for CSV |
 
-**Response:** CSV with columns `frame_number`, `<label> x`, `<label> y` for each marker label.
+**Response:** CSV with columns `frame_number`, `<label> x`, `<label> y` for each marker label, served with `Content-Type: text/csv` and `Content-Disposition: attachment; filename="trackpoints.csv"` so the browser downloads it rather than displaying it inline.
 With `format=json`: `{ "error": "False", "trackpoint_dicts": [...] }`.
 
 ---

--- a/jstests/canvas_controller.test.mjs
+++ b/jstests/canvas_controller.test.mjs
@@ -149,7 +149,7 @@ describe('CanvasController', () => {
     expect(controller.c.style.cursor).toBe('auto');
   });
 
-  test('resize updates both canvas and offscreen canvas dimensions', () => {
+  test('resize updates both canvas and offscreen canvas dimensions at default zoom (1)', () => {
     controller.resize(320, 240);
     expect(controller.c.width).toBe(320);
     expect(controller.c.height).toBe(240);
@@ -157,6 +157,19 @@ describe('CanvasController', () => {
     expect(controller.oc.height).toBe(240);
     expect(controller.naturalWidth).toBe(320);
     expect(controller.naturalHeight).toBe(240);
+  });
+
+  test('resize preserves current zoom — regression for #1020', () => {
+    // When a new background image loads after tracing (e.g. the traced video),
+    // resize() must apply the current zoom so the canvas stays at 200%, not 100%.
+    controller.set_zoom(2);
+    controller.resize(320, 240);
+    expect(controller.naturalWidth).toBe(320);
+    expect(controller.naturalHeight).toBe(240);
+    expect(controller.c.width).toBe(640);   // 320 * 2
+    expect(controller.c.height).toBe(480);  // 240 * 2
+    expect(controller.oc.width).toBe(640);
+    expect(controller.oc.height).toBe(480);
   });
 
   });

--- a/jstests/canvas_tracer_controller.test.mjs
+++ b/jstests/canvas_tracer_controller.test.mjs
@@ -757,15 +757,17 @@ describe('trace_movie_frames', () => {
     });
 
     // G. did_onload_callback ───────────────────────────────────────────────────
-    test('resizes canvas and video when metadata has no dimensions and image has valid natural size', async () => {
+    test('resizes video (not canvas) when metadata has no dimensions and image has valid natural size', async () => {
+        // Regression for #1020: canvas attr('width') must NOT be set directly — that bypasses
+        // zoom and resets the canvas to 100%. resize() in WebImage.onload already applies zoom.
+        // Only the video element layout dimensions are set here.
         const tc = await callTmf(makeEntries('frame_0000.jpg'), null, { width: null, height: null });
         jest.clearAllMocks();
         tc.did_onload_callback({ img: { naturalWidth: 640, naturalHeight: 480 } });
         const canvasIdx = mock$.mock.calls.findIndex(args => args[0] && args[0].includes(' #canvas-id'));
         const videoIdx  = mock$.mock.calls.findIndex(args => args[0] && args[0].includes(' video'));
-        expect(canvasIdx).toBeGreaterThanOrEqual(0);
+        expect(canvasIdx).toBe(-1);  // canvas must NOT be touched directly — zoom would be lost
         expect(videoIdx).toBeGreaterThanOrEqual(0);
-        expect(mock$.mock.results[canvasIdx].value.attr).toHaveBeenCalledWith('width', 640);
         expect(mock$.mock.results[videoIdx].value.attr).toHaveBeenCalledWith('height', 480);
     });
 

--- a/jstests/canvas_tracer_controller.test.mjs
+++ b/jstests/canvas_tracer_controller.test.mjs
@@ -363,6 +363,20 @@ describe('TracerController constructor', () => {
         expect(tc.total_frames).toBe(42);
         expect(tc.last_tracked_frame).toBe(41);
     });
+
+    test('download button is hidden on construction when not fully traced', () => {
+        const tc = new TracerController('div#tc', makeMovieMetadata({ total_frames: 0, last_frame_tracked: -1 }), 'k');
+        expect(tc.download_button.hide).toHaveBeenCalled();
+        expect(tc.download_button.show).not.toHaveBeenCalled();
+    });
+
+    test('download button is shown and enabled on construction when fully traced', () => {
+        // Regression test for #1019: download button must be prop('disabled', false)
+        // after tracing completes, not merely shown (show() does not clear disabled state).
+        const tc = new TracerController('div#tc', makeMovieMetadata({ total_frames: 5, last_frame_tracked: 4 }), 'k');
+        expect(tc.download_button.show).toHaveBeenCalled();
+        expect(tc.download_button.prop).toHaveBeenCalledWith('disabled', false);
+    });
 });
 
 // ── TracerController.getMaxViewableFrame ─────────────────────────────────────

--- a/jstests/canvas_tracer_controller.test.mjs
+++ b/jstests/canvas_tracer_controller.test.mjs
@@ -373,9 +373,13 @@ describe('TracerController constructor', () => {
     test('download button is shown and enabled on construction when fully traced', () => {
         // Regression test for #1019: download button must be prop('disabled', false)
         // after tracing completes, not merely shown (show() does not clear disabled state).
+        // Regression test for #918: hidden form inputs must also be re-enabled so they
+        // are included in the POST body (disabled inputs are excluded by HTML spec).
         const tc = new TracerController('div#tc', makeMovieMetadata({ total_frames: 5, last_frame_tracked: 4 }), 'k');
         expect(tc.download_button.show).toHaveBeenCalled();
         expect(tc.download_button.prop).toHaveBeenCalledWith('disabled', false);
+        expect(tc.dl_api_key.prop).toHaveBeenCalledWith('disabled', false);
+        expect(tc.dl_movie_id.prop).toHaveBeenCalledWith('disabled', false);
     });
 });
 

--- a/src/app/flask_api.py
+++ b/src/app/flask_api.py
@@ -519,7 +519,8 @@ def api_get_movie_trackpoints():
             frame_dicts[frame]['frame_number'] = frame
             writer.writerow(frame_dicts[frame])
         response = make_response(f.getvalue())
-        response.headers['Content-Type'] =  'text/csv'
+        response.headers['Content-Type'] = 'text/csv'
+        response.headers['Content-Disposition'] = 'attachment; filename="trackpoints.csv"'
         return response
 
 

--- a/src/app/static/canvas_controller.mjs
+++ b/src/app/static/canvas_controller.mjs
@@ -278,8 +278,10 @@ class CanvasController {
     }
 
     resize(width, height) {
-        this.oc.width = this.c.width = this.naturalWidth = width;
-        this.oc.height = this.c.height = this.naturalHeight = height;
+        this.naturalWidth = width;
+        this.naturalHeight = height;
+        this.oc.width = this.c.width = width * this.zoom;
+        this.oc.height = this.c.height = height * this.zoom;
         this.redraw();
     }
 

--- a/src/app/static/canvas_tracer_controller.mjs
+++ b/src/app/static/canvas_tracer_controller.mjs
@@ -157,6 +157,7 @@ class TracerController extends MovieController {
         }
         if (this.isFullyTraced()) {
             this.track_button.val(RETRACE_MOVIE);
+            this.download_button.prop('disabled', false);
             this.download_button.show();
             return;
         }

--- a/src/app/static/canvas_tracer_controller.mjs
+++ b/src/app/static/canvas_tracer_controller.mjs
@@ -159,6 +159,11 @@ class TracerController extends MovieController {
             this.track_button.val(RETRACE_MOVIE);
             this.download_button.prop('disabled', false);
             this.download_button.show();
+            // Re-enable the hidden form inputs so they are included in the POST body.
+            // set_movie_control_buttons() disables all inputs during tracking,
+            // and disabled inputs are excluded from HTML form submission.
+            this.dl_api_key.prop('disabled', false);
+            this.dl_movie_id.prop('disabled', false);
             return;
         }
         this.track_button.val(TRACE_MOVIE);

--- a/src/app/static/canvas_tracer_controller.mjs
+++ b/src/app/static/canvas_tracer_controller.mjs
@@ -697,7 +697,9 @@ async function trace_movie_frames(div_controller, movie_metadata, movie_zipfile_
             if (nw > 0 && nh > 0) {
                 cc.movie_metadata.width = nw;
                 cc.movie_metadata.height = nh;
-                $(cc.div_selector + ' #canvas-id').attr('width', nw).attr('height', nh);
+                // Do NOT set canvas attr('width'/'height') directly — that bypasses zoom and
+                // resets the canvas to natural (100%) size. resize() in WebImage.onload
+                // already ran before this callback and correctly applied cc.zoom.
                 $(cc.div_selector + ' video').attr('width', nw).attr('height', nh);
             }
         }

--- a/tests/movie_test.py
+++ b/tests/movie_test.py
@@ -21,6 +21,7 @@ from app import apikey
 
 from app.odb import API_KEY,MOVIE_ID,USER_ID
 from app.constants import MIME
+from app.schema import Trackpoint
 from app.s3_presigned import s3_client
 from app.constants import logger
 from .conftest import get_movie_bytes
@@ -577,6 +578,7 @@ def test_get_movie_metadata_rotation_coercion(new_movie):
     assert meta.get('width') == 100
     assert meta.get('height') == 200
 
+
     # None → coerced to 0 → no swap
     odb.set_movie_metadata(movie_id=movie_id, movie_metadata={'rotation': None})
     meta = odb.get_movie_metadata(movie_id=movie_id)
@@ -594,3 +596,25 @@ def test_get_movie_metadata_rotation_coercion(new_movie):
     meta = odb.get_movie_metadata(movie_id=movie_id)
     assert meta.get('width') == 100
     assert meta.get('height') == 200
+
+
+def test_get_movie_trackpoints_content_disposition(client, new_movie):
+    """Regression test for #918: get-movie-trackpoints must return Content-Disposition: attachment
+    so the browser downloads the file rather than displaying it inline."""
+    api_key = new_movie[API_KEY]
+    movie_id = new_movie[MOVIE_ID]
+
+    # Store a trackpoint so the CSV has a data row
+    tp = Trackpoint(x=10, y=20, label='plant', frame_number=0)
+    odb.put_frame_trackpoints(movie_id=movie_id, frame_number=0, trackpoints=[tp])
+
+    resp = client.post('/api/get-movie-trackpoints', data={'api_key': api_key, 'movie_id': movie_id})
+    assert resp.status_code == 200
+    assert 'text/csv' in resp.headers['Content-Type']
+    assert 'attachment' in resp.headers['Content-Disposition']
+
+    # CSV body must contain a header row and at least one data row
+    body = resp.data.decode('utf-8')
+    lines = [line for line in body.splitlines() if line.strip()]
+    assert len(lines) >= 2, f"Expected header + data row, got: {body!r}"
+    assert 'frame_number' in lines[0]


### PR DESCRIPTION
## Summary

- **#1019** — Download Trackpoints button was shown but remained disabled after tracing completed. `set_movie_control_buttons()` disables all inputs during tracking; `refreshTrackButtonState()` called `.show()` but not `.prop('disabled', false)`.
- **#918** — Clicking Download Trackpoints caused a 500 Internal Server Error with empty POST body. Two root causes: (1) `set_movie_control_buttons()` also disabled the hidden `api_key`/`movie_id` form inputs — disabled inputs are excluded from HTML form submission by spec; (2) the response was missing `Content-Disposition: attachment`, causing the browser to display the CSV inline instead of downloading it.
- **#1020** — Canvas size reset to 100% zoom after tracing completed, even when user had set 200%. Two root causes: (1) `resize()` in `CanvasController` set canvas dimensions to natural (unzoomed) size, ignoring `this.zoom`; (2) `did_onload_callback` in `trace_movie_frames` then called `$(canvas).attr('width', nw)` directly, which is equivalent to `canvas.width = nw` and bypasses zoom entirely, undoing the `resize()` fix.

## Test plan

- [ ] Set zoom to 200%, trace a movie — canvas stays at 200% after tracing completes
- [ ] After tracing, Download Trackpoints button is enabled (not grayed out)
- [ ] Clicking Download Trackpoints triggers a file download (not an inline browser tab), with correct CSV data
- [ ] `npm test` — 294 JS tests pass
- [ ] `make pytest` — 10 Python tests pass (1 pre-existing skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)