### PR TITLE
Release process: add make check step and update ReleaseHistory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,15 @@ Each line in the release notes should be a Markdown link to the issue/PR, e.g.:
 - [#966](https://github.com/Plant-Tracer/webapp/issues/966) Fix ESLint no-undef error: list_users called bare in users.js
 ```
 
+## Updating ReleaseHistory After a Release
+
+After creating the GitHub release, open a PR to update `docs/ReleaseHistory.rst`:
+
+1. Add a row to the release table at the top of the file (Name, Version, Date, link to the GitHub release tag).
+2. Add a summary section for the new release (above the previous release's summary), with a bullet per significant change derived from the release notes. The act of updating ReleaseHistory itself need not be mentioned in the summary.
+
+This PR should reference the tagging Issue (e.g. `refs #N`) so the work is traceable. It does **not** need its own separate GitHub Issue.
+
 ## Tagging a Release
 
 Before tagging, the version number **must** be updated via a normal feature branch + PR and merged to `main`. Once the version bump PR is merged:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,20 +201,25 @@ Before tagging, the version number **must** be updated via a normal feature bran
    - `src/app/constants.py` — `__version__ = 'X.Y.Z'`
    - `pyproject.toml` — `version = "X.Y.Z"`
 
-2. **Create a GitHub Issue** for the tag (so the tag references an issue, per project convention):
+2. **Run the full CI check** and confirm it passes:
+   ```bash
+   make check
+   ```
+
+3. **Create a GitHub Issue** for the tag (so the tag references an issue, per project convention):
    ```bash
    gh issue create --title "Tag main branch as <tag-name>" \
      --body "All PRs for <milestone> merged. Tag main with \`<tag-name>\`." \
      --milestone "<milestone-name>"
    ```
 
-3. **Tag and push** the already-bumped main (always use an annotated tag):
+4. **Tag and push** the already-bumped main (always use an annotated tag):
    ```bash
    git tag -a <tag-name> -m "refs #<issue-number>: tag main as <tag-name>"
    git push origin <tag-name>
    ```
 
-4. **Close the issue** referencing the tag:
+5. **Close the issue** referencing the tag:
    ```bash
    gh issue close <issue-number> --comment "Tagged as \`<tag-name>\`."
    ```

--- a/docs/ReleaseHistory.rst
+++ b/docs/ReleaseHistory.rst
@@ -35,9 +35,91 @@ Release History
      - 0.9.7
      - April 26, 2026
      - `Closed Issues <https://github.com/Plant-Tracer/webapp/releases/tag/ver-0.9.7>`__
+   * - May062026
+     - 0.9.7.3
+     - May 8, 2026
+     - `Closed Issues <https://github.com/Plant-Tracer/webapp/releases/tag/ver-0.9.7.3>`__
+   * - May122026
+     - 0.9.7.4
+     - May 12, 2026
+     - `Closed Issues <https://github.com/Plant-Tracer/webapp/releases/tag/ver-0.9.7.4>`__
+   * - May-16-2026
+     - 0.9.7.5
+     - May 16, 2026
+     - `Closed Issues <https://github.com/Plant-Tracer/webapp/releases/tag/ver-0.9.7.5>`__
+   * - May-16-2026-2
+     - 0.9.7.5.1
+     - May 16, 2026
+     - `Closed Issues <https://github.com/Plant-Tracer/webapp/releases/tag/ver-0.9.7.5.1>`__
+   * - May-27-2026
+     - 0.9.7.6
+     - May 27, 2026
+     - `Closed Issues <https://github.com/Plant-Tracer/webapp/releases/tag/ver-0.9.7.6>`__
+   * - May-28-2026
+     - 0.9.7.6.2
+     - May 28, 2026
+     - `Closed Issues <https://github.com/Plant-Tracer/webapp/releases/tag/ver-0.9.7.6.2>`__
 
 Release Notes
 -------------
+
+0.9.7.6.2 Summary
+*****************
+    * Analyze: fix Download Trackpoints CSV — was nearly empty and opened in a browser tab instead of downloading
+    * Analyze: Download Trackpoints button now correctly enabled after tracing completes
+    * Analyze: movie canvas no longer resets to 100% zoom after tracing completes
+
+0.9.7.6 Summary
+****************
+    * Movies: fix bug where all students could see unpublished movies of other students
+    * Movies: new uploads are now Published by default
+    * Movies: movie tables now sorted newest-first by default
+    * Movies: sortable columns via DataTables; table style matches Marker table on Analyze page
+    * Movies: added Research Use and Credit columns, editable by uploader
+    * Upload: research permission changed from checkbox to Yes/No radio buttons
+    * Upload: research use option now references a Contributor Agreement
+    * Upload: attribution name field pre-filled with user's display name
+    * Analyze: clarified RulerXXmm marker naming rules on page and in tutorial
+    * Developer: Jest coverage threshold enforced locally via ``npm run coverage``
+    * Developer docs: added Release Process documentation
+    * Process: documentation review required when completing any Issue or PR
+
+0.9.7.5.1 Summary
+******************
+    * Process: document annotated tag convention and linked issue numbers in release notes
+    * Process: improve release process documentation in CLAUDE.md
+
+0.9.7.5 Summary
+***************
+    * Users: fix several regressions — listing, formatting, duplicate sections, First/Last Seen columns
+    * Users: add names support to bulk registration
+    * Users: fix HTTP 500 error when registering a user
+    * Documentation: update User Tutorial to current prod functionality
+    * Documentation: update DynamoDB schema documentation; create Flask API endpoint reference
+    * Email: improve login email template HTML for better client compatibility
+    * Dev: add MAILER_DRY_RUN env variable and Mailpit local SMTP catcher for local email testing
+    * Dev: add PostToolUse hook to auto-check Sphinx docs build after editing docs/
+    * Process: document release process (milestone prep, tagging, release notes) in CLAUDE.md
+
+0.9.7.4 Summary
+***************
+    * Movies: fix exceptions when editing movie name or user fields
+    * Movies: show accurate movie status values
+    * Users: fix ReferenceError for bulk_register_setup
+    * Users: fix HTTP 500 error when registering a user
+    * Analyze: fix Download Trackpoints button not enabled
+    * Analyze: fix position graphs not taking up full canvas size
+    * Audit: fix Internal Server Error and ReferenceError
+    * Alerts: show with more spacing and yellow background
+    * Copyright: extend to 2026
+    * Research permission: update privacy policy
+
+0.9.7.3 Summary
+***************
+    * Documentation: update User Tutorial for new instance
+    * UI: match webapp look and feel to planttracer.com
+    * Developer docs: move to docs/Development/ subfolder
+    * Test: add canvas_tracer_controller.js unit tests
 
 0.9.7 Summary
 *************


### PR DESCRIPTION
## Summary

- Adds an explicit `make check` step to the "Tagging a Release" section of CLAUDE.md, requiring CI to pass before tagging (fixes #1024, item 3 of #992)
- Updates `docs/ReleaseHistory.rst` with table rows and summary sections for all releases since 0.9.7: 0.9.7.3, 0.9.7.4, 0.9.7.5, 0.9.7.5.1, 0.9.7.6, and 0.9.7.6.2 (fixes #1025)
- Adds a "Updating ReleaseHistory After a Release" section to CLAUDE.md documenting that a PR should update `docs/ReleaseHistory.rst` after each release (refs #1025)
- Updates upload_movie tutorial screenshot to show radio buttons (fixes #998)

## Test plan

- [ ] Sphinx docs build clean: `poetry run sphinx-build -W --keep-going -b html docs docs/_build/html`
- [ ] Review CLAUDE.md release process sections for accuracy
- [ ] Review ReleaseHistory.rst table and summaries for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)