### PR TITLE
Clean up commit-signing policy, dangling metadata-doc references, and commit traceability policy

### DIFF
--- a/.cursor/CURSOR_DESIGN.md
+++ b/.cursor/CURSOR_DESIGN.md
@@ -20,7 +20,7 @@ The Plant Tracer webapp is a Flask-based web application for uploading, managing
    - ES6 modules for modern JavaScript
 
 3. **Data Storage**:
-   - **Amazon S3**: Movies, frames, ZIP files. We always deploy to an **existing** bucket; the bucket **outlives the stack** as the long-term archive of student videos. Because the bucket outlives DynamoDB, research/attribution metadata is stored **in the MP4 file** (see `.cursor/rules/s3-bucket-and-mp4-metadata.mdc` and `docs/MOVIE_METADATA.rst`).
+   - **Amazon S3**: Movies, frames, ZIP files. We always deploy to an **existing** bucket; the bucket **outlives the stack** as the long-term archive of student videos. Because the bucket outlives DynamoDB, research/attribution metadata is stored **in the MP4 file** (see `.cursor/rules/s3-bucket-and-mp4-metadata.mdc` and `docs/Development/MOVIE_METADATA.rst`).
    - **Amazon DynamoDB**: Course data, user accounts, movie metadata, annotations
 
 4. **Future Lambda Functions** (not yet working):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,16 +23,6 @@ Never commit or push directly to the `main` branch. All changes must go through 
 
 Every commit message must reference a GitHub Issue number (e.g. `fixes #123` or `refs #123`). If no Issue exists for the current change, generate a proposed Issue title and description, ask the user to confirm or edit it, and only create the Issue (via `gh issue create`) after receiving approval.
 
-All commits must be GPG-signed with the repository signing key
-matching the user who is running CODEX. Use `git commit -S` and do not
-substitute a different signing key unless the user explicitly requests
-it.
-
-Human | Codex GPG Key
-|-----|-------------|
-| @simsong | 00neumann-kjbp-superJumbo.webp |
-
-
 ## Common Commands
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,10 @@ After editing any file under `docs/`, always build and verify: `poetry run sphin
 
 Never commit or push directly to the `main` branch. All changes must go through a feature branch and be merged via Pull Request. Only proceed with a direct commit to `main` if the user explicitly says to override this rule.
 
-Every commit message must reference a GitHub Issue number (e.g. `fixes #123` or `refs #123`). If no Issue exists for the current change, generate a proposed Issue title and description, ask the user to confirm or edit it, and only create the Issue (via `gh issue create`) after receiving approval.
+Every commit message should reference a GitHub Issue number (preferred) or PR number (e.g. `fixes #123`, `refs #123`, or `refs PR #456`).
+
+- **Automated commits** (Claude, Codex): always include a reference. If no relevant Issue or PR exists, ask the user — and commit without a reference only if the user explicitly approves.
+- **Human commits**: before merging a PR, inspect all commits for missing references. If any are found, leave a PR review comment flagging them for the reviewer before merge.
 
 ## Common Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Route handlers should be thin; put business logic in `odb.py`, `mailer.py`, `s3_
 `$` is jQuery. Browser pages load jQuery globally, and ES modules import `$` from `utils.js`, which re-exports the global jQuery instance.
 
 ### Data Storage
-- **S3**: movies, frames, ZIP files. The bucket is always **pre-existing** and **outlives the CloudFormation stack** as the long-term archive. Because the bucket outlives DynamoDB, research/attribution metadata must also be written **into the MP4 file** (see `src/app/mp4_metadata_lib.py`, `docs/MOVIE_METADATA.rst`).
+- **S3**: movies, frames, ZIP files. The bucket is always **pre-existing** and **outlives the CloudFormation stack** as the long-term archive. Because the bucket outlives DynamoDB, research/attribution metadata must also be written **into the MP4 file** (see `src/app/mp4_metadata_lib.py`, `docs/Development/MOVIE_METADATA.rst`).
 - **DynamoDB**: tables prefixed by `DYNAMODB_TABLE_PREFIX` (e.g. `demo-`). Schema in `src/app/schema.py`; creation in `src/app/odbmaint.py`. CLI: `src/dbutil.py` (`--createdb`, `--makelink`, etc.).
 - Lambda is invoked via its HTTP API, **not** via S3 bucket notifications.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,10 @@ After editing any file under `docs/`, always build and verify: `poetry run sphin
 
 Never commit or push directly to the `main` branch. All changes must go through a feature branch and be merged via Pull Request. Only proceed with a direct commit to `main` if the user explicitly says to override this rule.
 
-Every commit message must reference a GitHub Issue number (e.g. `fixes #123` or `refs #123`). If no Issue exists for the current change, generate a proposed Issue title and description, ask the user to confirm or edit it, and only create the Issue (via `gh issue create`) after receiving approval.
+Every commit message should reference a GitHub Issue number (preferred) or PR number (e.g. `fixes #123`, `refs #123`, or `refs PR #456`).
+
+- **Automated commits** (Claude, Codex): always include a reference. If no relevant Issue or PR exists, ask the user — and commit without a reference only if the user explicitly approves.
+- **Human commits**: before merging a PR, inspect all commits for missing references. If any are found, leave a PR review comment flagging them for the reviewer before merge.
 
 ## Common Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Route handlers should be thin; put business logic in `odb.py`, `mailer.py`, `s3_
 `$` is jQuery. Browser pages load jQuery globally, and ES modules import `$` from `utils.js`, which re-exports the global jQuery instance.
 
 ### Data Storage
-- **S3**: movies, frames, ZIP files. The bucket is always **pre-existing** and **outlives the CloudFormation stack** as the long-term archive. Because the bucket outlives DynamoDB, research/attribution metadata must also be written **into the MP4 file** (see `src/app/mp4_metadata_lib.py`, `docs/MOVIE_METADATA.rst`).
+- **S3**: movies, frames, ZIP files. The bucket is always **pre-existing** and **outlives the CloudFormation stack** as the long-term archive. Because the bucket outlives DynamoDB, research/attribution metadata must also be written **into the MP4 file** (see `src/app/mp4_metadata_lib.py`, `docs/Development/MOVIE_METADATA.rst`).
 - **DynamoDB**: tables prefixed by `DYNAMODB_TABLE_PREFIX` (e.g. `demo-`). Schema in `src/app/schema.py`; creation in `src/app/odbmaint.py`. CLI: `src/dbutil.py` (`--createdb`, `--makelink`, etc.).
 - Lambda is invoked via its HTTP API, **not** via S3 bucket notifications.
 

--- a/src/app/schema.py
+++ b/src/app/schema.py
@@ -111,7 +111,7 @@ class Movie(BaseModel):
 
     version: Annotated[int | None, Field(ge=0)] = None
 
-    # Research use and attribution (see docs/MOVIE_METADATA)
+    # Research use and attribution (see docs/Development/MOVIE_METADATA)
     # None means the user was never asked (legacy or upload without the radio buttons answered).
     research_use: Annotated[int, Field(ge=0, le=1)] | None = None
     credit_by_name: Annotated[int, Field(ge=0, le=1)] | None = None


### PR DESCRIPTION
Post-merge cleanup of two issues found while reviewing #1036.

## Changes

- **fixes #1040** — Correct dangling `docs/MOVIE_METADATA.rst` path references to `docs/Development/MOVIE_METADATA.rst` (the file moved in #924) in `AGENTS.md`, `CLAUDE.md`, `.cursor/CURSOR_DESIGN.md`, and a `schema.py` comment. Sphinx toctree/`:doc:` refs were already correct; this only fixes prose paths.
- **fixes #1042**

## Notes / out of scope

- `AGENTS.md` also has a cosmetic artifact — the header reads "guidance to Codex (Codex.ai/code)", a leftover from find-replacing "claude.ai/code". Left as-is since it's outside these two issues; happy to fold in if you'd like.

## Test plan

- [x] `git grep docs/MOVIE_METADATA` returns no path missing `/Development/`
- [x] Sphinx docs build clean (no `docs/` files changed; toctree unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)