### PR TITLE
Analyze: aggregate result statistics and Inflection Point marker

### DIFF
--- a/docs/Development/AnalysisResults.rst
+++ b/docs/Development/AnalysisResults.rst
@@ -1,0 +1,67 @@
+Analyze: Aggregate Result Statistics
+====================================
+
+After a movie is traced, the Analyze page computes aggregate statistics from the
+per-frame trackpoint data, in addition to the position-vs-time charts. The
+calculations are ported from the legacy iOS app's ``showResult()`` and live in the
+pure, DOM-free module ``src/app/static/analysis_results.mjs`` (issue #986). The
+display wiring lives in ``canvas_tracer_controller.mjs`` (``display_results()``).
+
+Result modes
+------------
+
+A selector on the Analyze page (``#result-mode-select``) chooses which statistics
+to show:
+
+* **All** (default) — both groups below.
+* **Gravitropism** — Distance and Angle.
+* **Circumnutation** — Max Amplitude.
+
+The tracked "tip" marker is the **Apex** if present, otherwise the first graphable
+(non-ruler) marker. Ruler markers set the millimeter scale; when two or more are
+present, distances are reported in mm, otherwise in pixels.
+
+Gravitropism
+------------
+
+Computed from the tip in the first and last (trimmed) frames, and the
+**Inflection Point** marker (see `Reserved marker names`_ below).
+
+* **Distance** — Euclidean displacement of the tip from first to last frame,
+  multiplied by the scale.
+* **Angle** — the bend at the inflection pivot, via the law of cosines. With
+  ``b`` = first-tip→first-inflection, ``c`` = last-tip→last-inflection, and
+  ``a`` = first-tip→last-tip::
+
+      angle = acos((b² + c² − a²) / (2·b·c)) · 180/π
+
+  The inflection point is tracked per frame, so ``b`` uses its first-frame
+  position and ``c`` its last-frame position. The angle is scale-invariant. It is
+  omitted when no inflection point is present or the triangle is degenerate (a tip
+  coincides with the inflection point).
+
+Circumnutation
+--------------
+
+* **Max Amplitude** — horizontal range of the tip over all (trimmed) frames,
+  ``(max x − min x) × scale``.
+
+Rate (deferred)
+---------------
+
+The legacy app also reported a **Rate** (displacement per unit time) using a
+hardcoded ``FPS = 20`` and the per-video frame rate. The web app stores a movie
+``fps`` field but has no working frame→time conversion yet, so Rate is not computed
+in this implementation. It is tracked as a follow-up to #986.
+
+Reserved marker names
+---------------------
+
+Two marker names are reserved and given special treatment:
+
+* ``Ruler Nmm`` (e.g. ``Ruler 0mm``, ``Ruler 10mm``) — define the mm/pixel scale;
+  excluded from graphing.
+* ``Inflection Point`` (matched **case-insensitively**) — the gravitropism pivot.
+  It is tracked and graphed like any plant marker, but its reserved name lets the
+  dedicated **Add Inflection Point** button and the Angle calculation locate it.
+  Only one is allowed per movie. See issue #1033.

--- a/docs/Development/index.rst
+++ b/docs/Development/index.rst
@@ -25,6 +25,7 @@ Developer Documentation
    FlaskAPI
    TrackpointCoordinateSystem
    trim-design
+   AnalysisResults
    ProcessingPhases
    THEORY_OF_DESIGN
    NOTES_ON_SIMPLIFYING

--- a/docs/UserTutorial.rst
+++ b/docs/UserTutorial.rst
@@ -83,6 +83,13 @@ Interpreting and Reading Results
 --------------------------------
 - Use the arrow buttons just below the tracked movie to play, or navigate to a particular frame.
 - The Position Graphs visualize the change in the non-RulerXX markers'horizontal (x position) and vertical (y position) since frame 0.
+- Above the graphs, Plant Tracer shows aggregate result statistics. Use the **Results** selector to choose **All**, **Gravitropism**, or **Circumnutation**:
+
+  - **Gravitropism** reports the **Distance** the tracked tip moved from the first to the last frame, and (when an Inflection Point marker is present) the bending **Angle** at that pivot.
+  - **Circumnutation** reports the **Max Amplitude**, the horizontal range of the tracked tip across all frames.
+
+  Results are shown in millimeters when two or more ruler markers are present, otherwise in pixels.
+- To compute the gravitropism Angle, click **Add Inflection Point** to place the reference pivot marker (the base or bend point of the stem), then position it like any other marker. The marker name ``Inflection Point`` is reserved (matched case-insensitively) and only one may be added per movie.
 - When tracking is complete, you can press the "Download Trackpoints" button to get the tracking data in CSV format.
 - At this point, you are ready to use a spreadsheet to further analyze and graph the data.
 

--- a/jstests/analysis_results.test.mjs
+++ b/jstests/analysis_results.test.mjs
@@ -1,0 +1,104 @@
+import {
+    gravitropism_results,
+    circumnutation_results,
+    inflection_angle,
+    distance_between,
+} from 'analysis_results.mjs';
+
+describe('distance_between', () => {
+    test('Euclidean distance (3-4-5)', () => {
+        expect(distance_between({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(5);
+    });
+});
+
+describe('gravitropism_results - distance', () => {
+    test('first->last displacement, pixels', () => {
+        const { distance } = gravitropism_results({
+            firstTip: { x: 0, y: 0 }, lastTip: { x: 3, y: 4 },
+        });
+        expect(distance).toBe(5);
+    });
+
+    test('scaled to mm', () => {
+        const { distance } = gravitropism_results({
+            firstTip: { x: 0, y: 0 }, lastTip: { x: 3, y: 4 }, scale: 2,
+        });
+        expect(distance).toBe(10);
+    });
+
+    test('null distance when a tip is missing', () => {
+        const { distance, angle } = gravitropism_results({ firstTip: { x: 0, y: 0 } });
+        expect(distance).toBeNull();
+        expect(angle).toBeNull();
+    });
+});
+
+describe('gravitropism_results - angle (law of cosines)', () => {
+    test('right angle (90 degrees)', () => {
+        const { angle } = gravitropism_results({
+            firstTip: { x: 0, y: 0 }, lastTip: { x: 2, y: 0 },
+            firstInflection: { x: 1, y: 1 }, lastInflection: { x: 1, y: 1 },
+        });
+        expect(angle).toBeCloseTo(90, 6);
+    });
+
+    test('straight line (180 degrees)', () => {
+        const { angle } = gravitropism_results({
+            firstTip: { x: 0, y: 0 }, lastTip: { x: 2, y: 0 },
+            firstInflection: { x: 1, y: 0 }, lastInflection: { x: 1, y: 0 },
+        });
+        expect(angle).toBeCloseTo(180, 6);
+    });
+
+    test('uses per-frame inflection positions (tracked per frame)', () => {
+        // Inflection moves between frames but the geometry still yields 180 degrees.
+        const { angle } = gravitropism_results({
+            firstTip: { x: 0, y: 0 }, lastTip: { x: 2, y: 0 },
+            firstInflection: { x: 0, y: 1 }, lastInflection: { x: 2, y: 1 },
+        });
+        expect(angle).toBeCloseTo(180, 6);
+    });
+
+    test('angle is scale-invariant', () => {
+        const args = {
+            firstTip: { x: 0, y: 0 }, lastTip: { x: 2, y: 0 },
+            firstInflection: { x: 1, y: 1 }, lastInflection: { x: 1, y: 1 },
+        };
+        const a1 = gravitropism_results({ ...args, scale: 1 }).angle;
+        const a5 = gravitropism_results({ ...args, scale: 5 }).angle;
+        expect(a5).toBeCloseTo(a1, 9);
+    });
+
+    test('null angle when no inflection point present', () => {
+        const { angle } = gravitropism_results({
+            firstTip: { x: 0, y: 0 }, lastTip: { x: 2, y: 0 },
+        });
+        expect(angle).toBeNull();
+    });
+
+    test('null angle when a tip coincides with the inflection point (degenerate)', () => {
+        const angle = inflection_angle(
+            { x: 1, y: 1 }, { x: 2, y: 0 }, { x: 1, y: 1 }, { x: 1, y: 1 });
+        expect(angle).toBeNull();
+    });
+});
+
+describe('circumnutation_results - max amplitude', () => {
+    test('horizontal x-range over all frames, pixels', () => {
+        const { maxAmplitude } = circumnutation_results({
+            tipPoints: [{ x: 5, y: 0 }, { x: 1, y: 9 }, { x: 9, y: 2 }, { x: 3, y: 4 }],
+        });
+        expect(maxAmplitude).toBe(8);
+    });
+
+    test('scaled to mm', () => {
+        const { maxAmplitude } = circumnutation_results({
+            tipPoints: [{ x: 1, y: 0 }, { x: 9, y: 0 }], scale: 2,
+        });
+        expect(maxAmplitude).toBe(16);
+    });
+
+    test('null when there are no points', () => {
+        expect(circumnutation_results({ tipPoints: [] }).maxAmplitude).toBeNull();
+    });
+});

--- a/jstests/canvas_tracer_controller.test.mjs
+++ b/jstests/canvas_tracer_controller.test.mjs
@@ -471,6 +471,23 @@ describe('TracerController inflection point', () => {
         expect(after).toBe(1);
     });
 
+    test('refreshFrameEditState enables the inflection button on an editable empty frame', () => {
+        const tc = new TracerController('div#tc', makeMovieMetadata(), 'k');
+        tc.isCurrentFrameEditable = () => true;
+        tc.add_inflection_point_button = { prop: jest.fn() };
+        tc.refreshFrameEditState();
+        expect(tc.add_inflection_point_button.prop).toHaveBeenCalledWith('disabled', false);
+    });
+
+    test('refreshFrameEditState disables the inflection button once one exists', () => {
+        const tc = new TracerController('div#tc', makeMovieMetadata(), 'k');
+        tc.isCurrentFrameEditable = () => true;
+        tc.objects.push(new MockMarkerClass(50, 50, 5, 'red', 'red', INFLECTION_POINT_LABEL));
+        tc.add_inflection_point_button = { prop: jest.fn() };
+        tc.refreshFrameEditState();
+        expect(tc.add_inflection_point_button.prop).toHaveBeenCalledWith('disabled', true);
+    });
+
     test('typed reserved name (any case) is blocked when one already exists', () => {
         const tc = new TracerController('div#tc', makeMovieMetadata(), 'k');
         tc.isCurrentFrameEditable = () => true;

--- a/jstests/canvas_tracer_controller.test.mjs
+++ b/jstests/canvas_tracer_controller.test.mjs
@@ -242,6 +242,10 @@ const {
     is_movie_tracked,
     create_default_markers,
     calc_scale,
+    is_inflection_marker_label,
+    is_graphable_marker,
+    INFLECTION_POINT_LABEL,
+    display_results,
     TracerController,
     trace_movie,
     trace_movie_one_frame,
@@ -399,6 +403,159 @@ describe('create_default_markers', () => {
             expect(typeof m.y).toBe('number');
             expect(typeof m.label).toBe('string');
         }
+    });
+});
+
+// ── Inflection Point marker (#1033) ──────────────────────────────────────────
+describe('is_inflection_marker_label', () => {
+    test('canonical name matches', () => {
+        expect(is_inflection_marker_label('Inflection Point')).toBe(true);
+    });
+
+    test('case-insensitive matches', () => {
+        expect(is_inflection_marker_label('inflection point')).toBe(true);
+        expect(is_inflection_marker_label('INFLECTION POINT')).toBe(true);
+        expect(is_inflection_marker_label('Inflection  Point')).toBe(true);
+        expect(is_inflection_marker_label('  Inflection Point  ')).toBe(true);
+    });
+
+    test('non-matches', () => {
+        expect(is_inflection_marker_label('Apex')).toBe(false);
+        expect(is_inflection_marker_label('Inflection')).toBe(false);
+        expect(is_inflection_marker_label('Ruler 0mm')).toBe(false);
+        expect(is_inflection_marker_label(null)).toBe(false);
+    });
+
+    test('the exported label constant is itself recognized', () => {
+        expect(is_inflection_marker_label(INFLECTION_POINT_LABEL)).toBe(true);
+    });
+});
+
+describe('inflection point stays graphable', () => {
+    test('inflection marker is graphable (plotted like any plant marker)', () => {
+        expect(is_graphable_marker({ label: INFLECTION_POINT_LABEL })).toBeTruthy();
+    });
+
+    test('ruler markers remain non-graphable', () => {
+        expect(is_graphable_marker({ label: 'Ruler 0mm' })).toBeFalsy();
+    });
+});
+
+describe('TracerController inflection point', () => {
+    afterEach(() => {
+        resetDollarMock();
+        resetPostMock();
+    });
+
+    test('has_inflection_marker reflects objects', () => {
+        const tc = new TracerController('div#tc', makeMovieMetadata(), 'k');
+        expect(tc.has_inflection_marker()).toBe(false);
+        tc.objects.push(new MockMarkerClass(50, 50, 5, 'red', 'red', INFLECTION_POINT_LABEL));
+        expect(tc.has_inflection_marker()).toBe(true);
+    });
+
+    test('has_inflection_marker is case-insensitive', () => {
+        const tc = new TracerController('div#tc', makeMovieMetadata(), 'k');
+        tc.objects.push(new MockMarkerClass(50, 50, 5, 'red', 'red', 'inflection point'));
+        expect(tc.has_inflection_marker()).toBe(true);
+    });
+
+    test('dedicated button adds one inflection point and refuses a second', () => {
+        const tc = new TracerController('div#tc', makeMovieMetadata(), 'k');
+        tc.isCurrentFrameEditable = () => true;
+        tc.add_inflection_point_onclick_handler();
+        const count = tc.objects.filter(o => is_inflection_marker_label(o.name)).length;
+        expect(count).toBe(1);
+        tc.add_inflection_point_onclick_handler();
+        const after = tc.objects.filter(o => is_inflection_marker_label(o.name)).length;
+        expect(after).toBe(1);
+    });
+
+    test('typed reserved name (any case) is blocked when one already exists', () => {
+        const tc = new TracerController('div#tc', makeMovieMetadata(), 'k');
+        tc.isCurrentFrameEditable = () => true;
+        tc.objects.push(new MockMarkerClass(50, 50, 5, 'red', 'red', INFLECTION_POINT_LABEL));
+        tc.marker_name_input = { val: () => 'inflection point' };
+        tc.marker_name_changed();
+        expect(tc.add_marker_status.text).toHaveBeenCalledWith(MARKER_NAME_IN_USE_MESSAGE);
+        expect(tc.add_marker_button.prop).toHaveBeenCalledWith('disabled', true);
+    });
+});
+
+// ── display_results (#986) ───────────────────────────────────────────────────
+describe('display_results', () => {
+    const cc = { isFrameInTrim: () => true, fpm: null };
+
+    function setupDom(mode = 'all') {
+        document.body.innerHTML =
+            `<select id="result-mode-select"><option value="all"></option>` +
+            `<option value="gravitropism"></option><option value="circumnutation"></option></select>` +
+            `<div id="result-stats"></div>`;
+        document.getElementById('result-mode-select').value = mode;
+        return document.getElementById('result-stats');
+    }
+
+    // Apex tip moves (0,0)->(3,4); inflection at (0,0)/(2,0); ruler gives 0.1 mm/px.
+    function framesWithInflection() {
+        return [
+            { frame_number: 0, markers: [
+                { label: 'Apex', x: 0, y: 0 },
+                { label: INFLECTION_POINT_LABEL, x: 0, y: 10 },
+                { label: 'Ruler 0mm', x: 0, y: 0 },
+                { label: 'Ruler 10mm', x: 100, y: 0 },
+            ] },
+            { frame_number: 1, markers: [
+                { label: 'Apex', x: 3, y: 4 },
+                { label: INFLECTION_POINT_LABEL, x: 2, y: 10 },
+                { label: 'Ruler 0mm', x: 0, y: 0 },
+                { label: 'Ruler 10mm', x: 100, y: 0 },
+            ] },
+        ];
+    }
+
+    test('all mode shows Distance, Angle and Max Amplitude', () => {
+        const el = setupDom('all');
+        display_results(cc, framesWithInflection());
+        expect(el.textContent).toMatch(/Distance:/);
+        expect(el.textContent).toMatch(/Angle:.*degree/);
+        expect(el.textContent).toMatch(/Max Amplitude:/);
+    });
+
+    test('gravitropism mode omits Max Amplitude', () => {
+        const el = setupDom('gravitropism');
+        display_results(cc, framesWithInflection());
+        expect(el.textContent).toMatch(/Distance:/);
+        expect(el.textContent).not.toMatch(/Max Amplitude:/);
+    });
+
+    test('circumnutation mode shows only Max Amplitude', () => {
+        const el = setupDom('circumnutation');
+        display_results(cc, framesWithInflection());
+        expect(el.textContent).toMatch(/Max Amplitude:/);
+        expect(el.textContent).not.toMatch(/Distance:/);
+        expect(el.textContent).not.toMatch(/Angle:/);
+    });
+
+    test('ruler markers convert distance to mm', () => {
+        const el = setupDom('gravitropism');
+        display_results(cc, framesWithInflection());
+        // displacement 5 px * 0.1 mm/px = 0.50 mm
+        expect(el.textContent).toMatch(/Distance: 0\.50 mm/);
+    });
+
+    test('gravitropism without an inflection point hints to add one', () => {
+        const el = setupDom('gravitropism');
+        const frames = framesWithInflection().map(f => ({
+            ...f, markers: f.markers.filter(m => !is_inflection_marker_label(m.label)),
+        }));
+        display_results(cc, frames);
+        expect(el.textContent).not.toMatch(/Angle:/);
+        expect(el.textContent).toMatch(/Add an Inflection Point/);
+    });
+
+    test('no #result-stats element is a no-op', () => {
+        document.body.innerHTML = '';
+        expect(() => display_results(cc, framesWithInflection())).not.toThrow();
     });
 });
 

--- a/src/app/static/analysis_results.mjs
+++ b/src/app/static/analysis_results.mjs
@@ -1,0 +1,98 @@
+"use strict";
+
+/* eslint-env es6 */
+/* see eslint.config for globals */
+/* jshint esversion: 8 */
+
+/*
+ * analysis_results.mjs
+ *
+ * Pure (DOM-free, unit-testable) aggregate trace-result statistics, ported from the
+ * legacy iOS app's Graph.js showResult(). See docs/Development/AnalysisResults.rst and
+ * issue #986.
+ *
+ * Two result groups:
+ *   - Gravitropism: Distance (first->last tip displacement) and Angle (bend at the
+ *     Inflection Point pivot, via the law of cosines).
+ *   - Circumnutation: Max Amplitude (horizontal x-range of the tip over all frames).
+ *
+ * Rate (displacement per unit time) is intentionally NOT computed here yet; the
+ * frame->time conversion is unresolved (see #986) and tracked as a follow-up.
+ *
+ * All inputs are points of the form {x, y} in a single consistent coordinate space.
+ * `scale` converts pixels to physical units (mm/pixel); pass 1 for pixels. Distance and
+ * Max Amplitude scale linearly; Angle is scale-invariant (the factor cancels), so it is
+ * always computed in the raw coordinate space.
+ */
+
+function distance_between(a, b) {
+    return Math.hypot(b.x - a.x, b.y - a.y);
+}
+
+function is_point(p) {
+    return p && Number.isFinite(Number(p.x)) && Number.isFinite(Number(p.y));
+}
+
+/*
+ * Gravitropism results.
+ *
+ * @param {object}  firstTip        tip position in the first frame {x, y}
+ * @param {object}  lastTip         tip position in the last frame {x, y}
+ * @param {object?} firstInflection inflection-point position in the first frame {x, y}
+ * @param {object?} lastInflection  inflection-point position in the last frame {x, y}
+ * @param {number}  scale           mm/pixel (default 1 = pixels)
+ *
+ * Returns { distance, angle } where angle is in degrees, or null when no inflection
+ * point is available or the angle is degenerate (a tip coincides with the inflection
+ * point, making the triangle undefined).
+ */
+function gravitropism_results({ firstTip, lastTip, firstInflection = null,
+                                lastInflection = null, scale = 1 } = {}) {
+    if (!is_point(firstTip) || !is_point(lastTip)) {
+        return { distance: null, angle: null };
+    }
+    const distance = distance_between(firstTip, lastTip) * scale;
+    const angle = inflection_angle(firstTip, lastTip, firstInflection, lastInflection);
+    return { distance, angle };
+}
+
+/*
+ * Bend angle (degrees) at the inflection pivot, via the law of cosines.
+ * b = first tip -> first inflection, c = last tip -> last inflection,
+ * a = first tip -> last tip. Computed in raw coordinates (scale cancels).
+ * Returns null when no inflection point is available or the triangle is degenerate.
+ */
+function inflection_angle(firstTip, lastTip, firstInflection, lastInflection) {
+    if (!is_point(firstInflection) || !is_point(lastInflection)) {
+        return null;
+    }
+    const b = distance_between(firstTip, firstInflection);
+    const c = distance_between(lastTip, lastInflection);
+    const a = distance_between(firstTip, lastTip);
+    if (b === 0 || c === 0) {
+        return null;
+    }
+    let cos_angle = (b * b + c * c - a * a) / (2 * b * c);
+    // Guard against floating-point drift outside the valid acos domain.
+    cos_angle = Math.max(-1, Math.min(1, cos_angle));
+    return Math.acos(cos_angle) * 180 / Math.PI;
+}
+
+/*
+ * Circumnutation results.
+ *
+ * @param {Array}  tipPoints  tip positions {x, y} across all (trimmed) frames
+ * @param {number} scale      mm/pixel (default 1 = pixels)
+ *
+ * Returns { maxAmplitude } = (max x - min x) * scale, or null when there are no points.
+ */
+function circumnutation_results({ tipPoints = [], scale = 1 } = {}) {
+    const xs = (tipPoints || []).filter(is_point).map(p => Number(p.x));
+    if (xs.length === 0) {
+        return { maxAmplitude: null };
+    }
+    const maxAmplitude = (Math.max(...xs) - Math.min(...xs)) * scale;
+    return { maxAmplitude };
+}
+
+export { gravitropism_results, circumnutation_results, inflection_angle, distance_between };

--- a/src/app/static/canvas_tracer_controller.mjs
+++ b/src/app/static/canvas_tracer_controller.mjs
@@ -17,6 +17,12 @@ const MARKER_RADIUS = 10;           // default radius of the marker
 const RULER_MARKER_COLOR = 'red';
 const APEX_MARKER_COLOR = 'orange';
 const FIXED_PLANT_MARKER_COLORS = ['magenta', '#b58900', '#0096ff'];
+// Reserved marker used as the fixed pivot for the gravitropism Angle statistic.
+// The name is matched case-insensitively; the marker is tracked and graphed like any
+// plant marker, but its reserved name lets the dedicated button and the Angle
+// calculation locate it.
+const INFLECTION_POINT_LABEL = 'Inflection Point';
+const INFLECTION_MARKER_COLOR = '#2aa198';
 const MIN_MARKER_NAME_LEN = 4;  // markers must be this long (allows 'apex')
 const TRACING_COMPLETED_FLAG='tracing completed';
 const TRACING_FLAG='tracing';
@@ -59,6 +65,7 @@ import {
 import { CanvasItem, Marker,Line } from "./canvas_controller.mjs";
 import { MovieController } from "./canvas_movie_controller.js"
 import { unzip, setOptions } from './unzipit.module.mjs';
+import { gravitropism_results, circumnutation_results } from "./analysis_results.mjs";
 
 // Default marker positions used only when a new movie is first loaded for analysis
 // and frame 0 has no markers yet (no frames traced). See create_default_markers().
@@ -126,6 +133,11 @@ function is_apex_marker_label(label) {
     return label === 'Apex';
 }
 
+// Case-insensitive: "Inflection Point", "inflection point", "INFLECTION POINT" all match.
+function is_inflection_marker_label(label) {
+    return typeof label === 'string' && /^\s*Inflection\s*Point\s*$/i.test(label);
+}
+
 function marker_is_undeletable(marker) {
     return marker && marker.undeletable === true;
 }
@@ -146,7 +158,8 @@ function graphable_marker_label(label) {
 }
 
 function custom_marker_label(label) {
-    return graphable_marker_label(label) && !is_apex_marker_label(label);
+    return graphable_marker_label(label) && !is_apex_marker_label(label)
+        && !is_inflection_marker_label(label);
 }
 
 function random_marker_color() {
@@ -243,6 +256,13 @@ class TracerController extends MovieController {
         // We need to be able to enable or display the add_marker button, so we record it
         this.add_marker_button = $(this.div_selector + " input.add_marker_button");
         this.add_marker_button.off('click').on('click', (event) => { this.add_marker_onclick_handler(event);});
+
+        this.add_inflection_point_button = $(this.div_selector + " input.add_inflection_point_button");
+        this.add_inflection_point_button.off('click').on('click', (event) => { this.add_inflection_point_onclick_handler(event);});
+
+        // Results mode selector (All / Gravitropism / Circumnutation) lives in #analysis-results.
+        this.result_mode_select = $("#result-mode-select");
+        this.result_mode_select.off('change').on('change', () => { this.refreshResults(); });
 
         // Set up the track button
         this.track_button = $(this.div_selector + " input.track_button");
@@ -419,6 +439,9 @@ class TracerController extends MovieController {
         if (is_apex_marker_label(label)) {
             return APEX_MARKER_COLOR;
         }
+        if (is_inflection_marker_label(label)) {
+            return INFLECTION_MARKER_COLOR;
+        }
         const existingColor = this.marker_color_from_existing_data(label);
         if (existingColor) {
             this.marker_colors_by_label.set(label, existingColor);
@@ -459,7 +482,17 @@ class TracerController extends MovieController {
 
     refreshVisibleGraphs() {
         if ($('#analysis-results').is(':visible')) {
-            requestAnimationFrame(() => graph_data(this, this.frames_for_graph()));
+            requestAnimationFrame(() => {
+                graph_data(this, this.frames_for_graph());
+                display_results(this, this.frames_for_graph());
+            });
+        }
+    }
+
+    // Recompute the result statistics for the current mode-selector value.
+    refreshResults() {
+        if ($('#analysis-results').is(':visible')) {
+            display_results(this, this.frames_for_graph());
         }
     }
 
@@ -727,6 +760,13 @@ class TracerController extends MovieController {
             this.add_marker_status.text("");
             this.add_marker_button.prop(DISABLED,false);
         }
+        // Reject a second inflection point regardless of casing (the reserved name is
+        // matched case-insensitively, so an exact-name check below would miss "inflection point").
+        if (is_inflection_marker_label(val) && this.has_inflection_marker()) {
+            this.add_marker_status.text(MARKER_NAME_IN_USE_MESSAGE);
+            this.add_marker_button.prop(DISABLED,true);
+            return;
+        }
         // Make sure it isn't in use
         for (let i=0;i<this.objects.length; i++){
             if(this.objects[i].name == val){
@@ -739,6 +779,12 @@ class TracerController extends MovieController {
         this.add_marker_button.prop(DISABLED,false);
     }
 
+    // True if a marker with the reserved Inflection Point name already exists.
+    has_inflection_marker() {
+        return (this.objects || []).some(
+            obj => obj.constructor.name === Marker.name && is_inflection_marker_label(obj.name));
+    }
+
     // new marker added
     add_marker_onclick_handler(_e) {
         if (!this.isCurrentFrameEditable()) {
@@ -748,6 +794,18 @@ class TracerController extends MovieController {
             this.add_marker( 50, 50, this.marker_name_input.val());
             this.marker_name_input.val("");
         }
+    }
+
+    // Add the reserved Inflection Point marker via its dedicated button.
+    add_inflection_point_onclick_handler(_e) {
+        if (!this.isCurrentFrameEditable()) {
+            return;
+        }
+        if (this.has_inflection_marker()) {
+            this.add_marker_status.text(MARKER_NAME_IN_USE_MESSAGE);
+            return;
+        }
+        this.add_marker(50, 50, INFLECTION_POINT_LABEL);
     }
 
     // add a tracking circle with the next color
@@ -1713,7 +1771,10 @@ async function trace_movie_frames(div_controller, movie_metadata, movie_zipfile_
     // Track button label and download visibility are set in constructor from last_tracked_frame / total_frames.
     if (show_results) {
         $('#analysis-results').show();
-        requestAnimationFrame(() => graph_data(cc, movie_frames));
+        requestAnimationFrame(() => {
+            graph_data(cc, movie_frames);
+            display_results(cc, movie_frames);
+        });
     }
 }
 
@@ -1779,6 +1840,92 @@ function first_marker_for_label(frames, label) {
         }
     }
     return null;
+}
+
+function last_marker_for_label(frames, label) {
+    for (let i = frames.length - 1; i >= 0; i--) {
+        const marker = marker_for_label(frames[i].markers, label);
+        if (marker) {
+            return marker;
+        }
+    }
+    return null;
+}
+
+// The tracked "tip" for result statistics: Apex if present, else the first graphable
+// non-inflection marker. The inflection point is graphable but is the pivot, not the tip.
+function result_tip_label(frames) {
+    const labels = graph_marker_labels(frames).filter(label => !is_inflection_marker_label(label));
+    if (labels.includes('Apex')) {
+        return 'Apex';
+    }
+    return labels.length ? labels[0] : null;
+}
+
+function result_inflection_label(frames) {
+    return graph_marker_labels(frames).find(label => is_inflection_marker_label(label)) || null;
+}
+
+function current_result_mode() {
+    const select = document.getElementById('result-mode-select');
+    return select ? select.value : 'all';
+}
+
+function result_units_word(pos_units) {
+    return pos_units === 'mm' ? 'mm' : 'pixel';
+}
+
+function format_measure(value) {
+    return Number(value).toFixed(2);
+}
+
+// Compute and render the aggregate statistics into #result-stats per the mode selector.
+function display_results(cc, frames) {
+    const container = document.getElementById('result-stats');
+    if (!container) {
+        return;
+    }
+    const mode = current_result_mode();
+    const graphFrames = frames.filter((frame, frameIndex) => frame_in_graph_trim(cc, frame, frameIndex));
+    const firstFrame = graphFrames[0];
+    const { scale, pos_units } = firstFrame
+        ? calc_scale(firstFrame.markers || [])
+        : { scale: 1, pos_units: 'pixels' };
+    const units = result_units_word(pos_units);
+
+    const tipLabel = result_tip_label(graphFrames);
+    const inflectionLabel = result_inflection_label(graphFrames);
+    const lines = [];
+
+    if (mode === 'all' || mode === 'gravitropism') {
+        const { distance, angle } = gravitropism_results({
+            firstTip: tipLabel ? first_marker_for_label(graphFrames, tipLabel) : null,
+            lastTip: tipLabel ? last_marker_for_label(graphFrames, tipLabel) : null,
+            firstInflection: inflectionLabel ? first_marker_for_label(graphFrames, inflectionLabel) : null,
+            lastInflection: inflectionLabel ? last_marker_for_label(graphFrames, inflectionLabel) : null,
+            scale,
+        });
+        if (distance != null) {
+            lines.push(`Distance: ${format_measure(distance)} ${units}`);
+        }
+        if (angle != null) {
+            lines.push(`Angle: ${format_measure(angle)} degree`);
+        } else if (mode === 'gravitropism' && !inflectionLabel) {
+            lines.push('Add an Inflection Point marker to compute the bending angle.');
+        }
+    }
+
+    if (mode === 'all' || mode === 'circumnutation') {
+        const tipPoints = tipLabel
+            ? graphFrames.map(frame => marker_for_label(frame.markers, tipLabel)).filter(marker => marker)
+            : [];
+        const { maxAmplitude } = circumnutation_results({ tipPoints, scale });
+        if (maxAmplitude != null) {
+            lines.push(`Max Amplitude: ${format_measure(maxAmplitude)} ${units}`);
+        }
+    }
+
+    container.innerHTML = lines.map(line => `<div>${html_escape(line)}</div>`).join('');
 }
 
 function graph_marker_color(cc, frames, label) {
@@ -2026,4 +2173,6 @@ function is_movie_tracked(metadata) {
 
 export { TracerController, trace_movie, trace_movie_one_frame, trace_movie_frames,
          get_ruler_size, frame_index_from_zip_name, is_movie_tracked,
-         create_default_markers, calc_scale };
+         create_default_markers, calc_scale,
+         is_inflection_marker_label, is_graphable_marker, INFLECTION_POINT_LABEL,
+         display_results };

--- a/src/app/static/canvas_tracer_controller.mjs
+++ b/src/app/static/canvas_tracer_controller.mjs
@@ -521,6 +521,10 @@ class TracerController extends MovieController {
         const editable = this.isCurrentFrameEditable();
         this.marker_name_input.prop(DISABLED, !editable);
         this.refreshResetTracingButtonState();
+        if (this.add_inflection_point_button) {
+            // Enabled only on an editable frame that does not already have one.
+            this.add_inflection_point_button.prop(DISABLED, !editable || this.has_inflection_marker());
+        }
         if (!editable) {
             this.add_marker_button.prop(DISABLED, true);
             this.track_button.prop(DISABLED, true);
@@ -820,6 +824,7 @@ class TracerController extends MovieController {
         this.create_marker_table(); // redraw table
         this.markFutureFramesDirty();
         this.refreshResetTracingButtonState();
+        this.refreshFrameEditState(); // keep the inflection-point button in sync
         // Finally enable the track-to-end button
         this.track_button.prop(DISABLED,false);
     }
@@ -1146,6 +1151,7 @@ class TracerController extends MovieController {
         this.create_marker_table();
         this.markFutureFramesDirty();
         this.refreshResetTracingButtonState();
+        this.refreshFrameEditState(); // re-enable the inflection-point button if it was removed
         this.put_markers();
     }
 

--- a/src/app/templates/tracer_app.html
+++ b/src/app/templates/tracer_app.html
@@ -73,6 +73,8 @@
           <label for='marker-name-id'>Marker name:</label>
           <input id='marker-name-id' class='marker_name_input' type='text' placeholder='Marker name' size='20'>
           <input class='add_marker_button pure-button  pure-button-primary' type='button' value='Add new marker' disabled='true'>
+          <input class='add_inflection_point_button pure-button' type='button' value='Add Inflection Point'
+                 title='Add the reference pivot used for the gravitropism Angle statistic'>
         </div>
 
         <div class='pure-control-group nodemo'>
@@ -115,6 +117,15 @@
     </form>
   </div>
   <div id="analysis-results">
+    <div class="result-controls">
+      <label for="result-mode-select">Results:</label>
+      <select id="result-mode-select" class="result_mode_select">
+        <option value="all" selected>All</option>
+        <option value="gravitropism">Gravitropism</option>
+        <option value="circumnutation">Circumnutation</option>
+      </select>
+    </div>
+    <div id="result-stats" class="result-stats"></div>
     <canvas id="apex-xChart" width="400" height="200"></canvas>
     <canvas id="apex-yChart" width="400" height="200"></canvas>
   </div>


### PR DESCRIPTION
fixes #986
fixes #1033

## Summary

Adds aggregate trace-result statistics to the Analyze page and the Inflection Point marker the gravitropism Angle depends on.

- **Result statistics** (#986): a new pure module `src/app/static/analysis_results.mjs` computes gravitropism **Distance** and **Angle** (law of cosines at the inflection pivot) and circumnutation **Max Amplitude**. A 3-way **Results** selector (All / Gravitropism / Circumnutation, default All) chooses what is shown; results display in millimeters when two or more ruler markers are present, otherwise pixels.
- **Inflection Point marker** (#1033): a reserved, case-insensitive marker name created via a dedicated **Add Inflection Point** button. It is tracked and graphed like any plant marker; only one is allowed per movie, and the button is disabled once one exists or the frame is not editable.
- **Rate is deferred** to #1053 (the frame-to-time conversion is unresolved); Distance, Angle, and Max Amplitude ship now.

## Tests
- New `jstests/analysis_results.test.mjs` (distance, angle, max amplitude, scaling, degenerate/empty cases).
- New cases in `jstests/canvas_tracer_controller.test.mjs` for the reserved-name helper, button add/dedup, button enable/disable state, and the results display.

## Docs
- New `docs/Development/AnalysisResults.rst` (formulas, reserved marker names, deferred Rate) and a section in `docs/UserTutorial.rst`.

## Verification
- `make check` passes (pylint 10.00/10; pytest 163 passed, 1 skipped; JS 417 passed). Sphinx docs build clean with `-W`.

## Notes for review
- The Angle uses the inflection point's first-frame position for `b` and its last-frame position for `c` (it is tracked per frame) — flagged as an assumption to confirm.