### PR TITLE
Add capture interval analysis units

### DIFF
--- a/docs/Development/AnalysisResults.rst
+++ b/docs/Development/AnalysisResults.rst
@@ -45,14 +45,32 @@ Circumnutation
 
 * **Max Amplitude** — horizontal range of the tip over all (trimmed) frames,
   ``(max x − min x) × scale``.
+* **Rate** — ``Max Amplitude ÷ elapsed time between the x-extreme frames`` (legacy
+  semantics; see #1053). Null when the extremes fall on the same frame.
 
-Rate (deferred)
----------------
+Rate and the capture interval (fpm)
+-----------------------------------
 
-The legacy app also reported a **Rate** (displacement per unit time) using a
-hardcoded ``FPS = 20`` and the per-video frame rate. The web app stores a movie
-``fps`` field but has no working frame→time conversion yet, so Rate is not computed
-in this implementation. It is tracked as a follow-up to #986.
+Rate is displacement per unit time. The time base is the **capture interval**
+``fpm`` (frames per minute), a per-movie value the user supplies at upload or on the
+Analyze page (#1056). The conversion is::
+
+   elapsed_time(min) = frame_span ÷ fpm
+
+* **Gravitropism Rate** = ``Distance ÷ elapsed_time`` over the first→last frame.
+* **Circumnutation Rate** = ``Max Amplitude ÷ elapsed_time`` between the frames of
+  the minimum and maximum x.
+
+When ``fpm`` is unset (legacy movies, or not yet entered), the graph x-axis stays in
+frames and Rate is reported **per frame** (``mm/frame`` or ``pixel/frame``); once a
+positive ``fpm`` is set it is reported **per minute**. ``fpm`` is distinct from the
+encoded playback ``fps`` and is stored as a string on the movie row (authoritative)
+with a best-effort snapshot in the traced MP4 (see
+:doc:`MOVIE_METADATA`). Editing ``fpm`` on the Analyze page only rescales time and
+rate — it does not require retracing.
+
+This replaces the legacy ``frames × 20 ÷ framerate`` formula (an iOS playback-time
+artifact); the ``FPS = 20`` constant is not used.
 
 Reserved marker names
 ---------------------

--- a/docs/Development/FlaskAPI.md
+++ b/docs/Development/FlaskAPI.md
@@ -192,6 +192,7 @@ first frame from lambda-resize and links the user to Analyze.
 | `research_use` | No | `"1"` = yes, `"0"` = no, omit = not answered |
 | `credit_by_name` | No | `"1"` = yes, `"0"` = no, omit = not answered (only meaningful when `research_use=1`) |
 | `attribution_name` | No | Attribution name (only stored when `credit_by_name=1`) |
+| `fpm` | No | Capture interval in frames/minute (time-lapse). Positive number, fractional allowed; stored on the movie and included as `x-amz-meta-fpm` in the presigned post |
 
 **Response**
 
@@ -404,6 +405,31 @@ Set one inclusive trim bound for a movie. Exactly one of `trim_start_frame` or
 
 Returns HTTP 400 with `error: true` if both or neither trim frame parameter is provided, or if
 the resulting trim bounds are invalid (e.g. `trim_start_frame > trim_end_frame`).
+
+---
+
+#### `POST /api/set-movie-fpm`
+
+Set the capture interval (frames/minute) for a movie. Owner or course admin only.
+Editing this value only rescales the Analyze time axis and Rate statistics; it does
+not require retracing. See `docs/Development/AnalysisResults.rst`.
+
+**Parameters**
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `api_key` | Yes | Must not be the demo key |
+| `movie_id` | Yes | |
+| `fpm` | Yes | Capture interval in frames/minute. Positive number, fractional allowed (e.g. `0.5`) |
+
+**Response**
+
+```text
+{ "error": false, "metadata": { "movie_id": "m...", "fpm": "30", ... } }
+```
+
+Returns HTTP 400 with `error: true` if `fpm` is missing, non-numeric, not positive, or above the
+allowed maximum.
 
 ---
 

--- a/docs/Development/MOVIE_METADATA.rst
+++ b/docs/Development/MOVIE_METADATA.rst
@@ -121,3 +121,27 @@ Traceability
 - **S3:** Each object has the same information in ``x-amz-meta-*``, so that
   exports, copies, or downstream systems can enforce or display attribution
   and research-use without relying solely on the application database.
+
+Capture interval (frames per minute)
+====================================
+
+The **capture interval** ``fpm`` (frames per minute) is a separate, optional
+per-movie value used by the Analyze page to report results per minute of real
+time (see :doc:`AnalysisResults` and issues #1056/#1053). It is distinct from the
+encoded playback ``fps``.
+
+- **DynamoDB is authoritative.** ``fpm`` is stored as a string on the movie row
+  (``schema.Movie.fpm``; ``odb.FPM``) and is what the application reads and edits.
+  The user can set it at upload (``/api/new-movie``) or later on the Analyze page
+  (``POST /api/set-movie-fpm``); editing it only rescales time/rate and never
+  requires retracing.
+- **S3 object metadata.** When supplied at upload, ``fpm`` is included in the
+  presigned ``Fields`` as ``x-amz-meta-fpm`` (``make_presigned_post``), like the
+  attribution fields.
+- **MP4 file (best-effort snapshot).** When a movie is processed, the capture
+  interval is written into the traced MP4 as a dedicated freeform atom
+  (``----:com.planttracer:capture_fpm``; ``mp4_metadata_lib.set_fpm`` /
+  ``get_fpm``), separate from the research-attribution comment atom. This is a
+  best-effort archival snapshot of the value at processing time; later Analyze-page
+  edits update only DynamoDB, so the embedded copy may lag the authoritative row.
+  Legacy movies have no atom, which is harmless.

--- a/docs/UserTutorial.rst
+++ b/docs/UserTutorial.rst
@@ -120,7 +120,9 @@ Converting Frames to Time
 
 If you enter the **capture interval (frames/minute)** — on the Upload page or in the field on the Analyze page — Plant Tracer converts frames to elapsed time for you: the position graphs are labeled in minutes and the **Rate** statistics are reported per minute. The capture interval is the number of time-lapse frames captured per minute of real time (for example, one frame every two minutes is ``0.5`` frames/minute). It is independent of the movie's encoded playback frame rate.
 
-If you do **not** enter a capture interval, the webapp tracks time only as frame numbers and reports Rate per frame; it is then up to the user to convert frames to elapsed timestamps as described below. When recording the movie, the frame period was set: you must know what that was. In Lapse-It, this is one of the parameters set for the recording. Typically, the frame period is one frame every two minutes (120 seconds) or 30 frames per hour.
+If you do **not** enter a capture interval, the webapp tracks time only as frame numbers and reports Rate per frame; it is then up to the user to convert frames to elapsed timestamps as described below. When recording the movie, the frame period was set: you must know what that was. In Lapse-It, this is one of the parameters set for the recording. Typically, the frame period is one frame every two minutes (120 seconds) or 0.5 frames per minute.
+
+While the program automatically does these conversions for you when a capture interval is present, here are the calculations if you need to do them yourself.
 
 To convert frame numbers to time, multiply the frame number by the frame period:
 

--- a/docs/UserTutorial.rst
+++ b/docs/UserTutorial.rst
@@ -85,10 +85,11 @@ Interpreting and Reading Results
 - The Position Graphs visualize the change in the non-RulerXX markers'horizontal (x position) and vertical (y position) since frame 0.
 - Above the graphs, Plant Tracer shows aggregate result statistics. Use the **Results** selector to choose **All**, **Gravitropism**, or **Circumnutation**:
 
-  - **Gravitropism** reports the **Distance** the tracked tip moved from the first to the last frame, and (when an Inflection Point marker is present) the bending **Angle** at that pivot.
-  - **Circumnutation** reports the **Max Amplitude**, the horizontal range of the tracked tip across all frames.
+  - **Gravitropism** reports the **Distance** the tracked tip moved from the first to the last frame, a **Rate**, and (when an Inflection Point marker is present) the bending **Angle** at that pivot.
+  - **Circumnutation** reports the **Max Amplitude**, the horizontal range of the tracked tip across all frames, and a **Rate**.
 
   Results are shown in millimeters when two or more ruler markers are present, otherwise in pixels.
+- **Rate** is reported per minute when you have entered the capture interval (frames/minute); otherwise it is reported per frame. Enter the capture interval in the **Capture interval (frames/minute)** field and click **Set** — the graphs' time axis and the Rate update immediately, with no need to retrace. You can also set it on the Upload page.
 - To compute the gravitropism Angle, click **Add Inflection Point** to place the reference pivot marker (the base or bend point of the stem), then position it like any other marker. The marker name ``Inflection Point`` is reserved (matched case-insensitively) and only one may be added per movie.
 - When tracking is complete, you can press the "Download Trackpoints" button to get the tracking data in CSV format.
 - At this point, you are ready to use a spreadsheet to further analyze and graph the data.
@@ -117,7 +118,9 @@ Further Adjustments to Tracking
 Converting Frames to Time
 -------------------------
 
-Currently, the Plant Tracer webapp tracks time only as frame numbers in the uploaded movie file. It is up to the the user to convert frames to elapsed timestamps from the beginning of the video. When recording the movie, the frame period was set: you must know what that was. In Lapse-It, this is one of the parameters set for the recording. Typically, the frame period is one frame every two minutes (120 seconds) or 30 frames per hour.
+If you enter the **capture interval (frames/minute)** — on the Upload page or in the field on the Analyze page — Plant Tracer converts frames to elapsed time for you: the position graphs are labeled in minutes and the **Rate** statistics are reported per minute. The capture interval is the number of time-lapse frames captured per minute of real time (for example, one frame every two minutes is ``0.5`` frames/minute). It is independent of the movie's encoded playback frame rate.
+
+If you do **not** enter a capture interval, the webapp tracks time only as frame numbers and reports Rate per frame; it is then up to the user to convert frames to elapsed timestamps as described below. When recording the movie, the frame period was set: you must know what that was. In Lapse-It, this is one of the parameters set for the recording. Typically, the frame period is one frame every two minutes (120 seconds) or 30 frames per hour.
 
 To convert frame numbers to time, multiply the frame number by the frame period:
 

--- a/jstests/analysis_results.test.mjs
+++ b/jstests/analysis_results.test.mjs
@@ -102,3 +102,76 @@ describe('circumnutation_results - max amplitude', () => {
         expect(circumnutation_results({ tipPoints: [] }).maxAmplitude).toBeNull();
     });
 });
+
+describe('gravitropism_results - rate', () => {
+    const base = { firstTip: { x: 0, y: 0 }, lastTip: { x: 3, y: 4 } }; // distance 5
+
+    test('per-minute rate uses frames / fpm', () => {
+        const { rate, rateTimeUnit } = gravitropism_results({
+            ...base, firstFrameNumber: 0, lastFrameNumber: 10, fpm: 5,
+        });
+        // elapsed = 10 frames / 5 fpm = 2 min; rate = 5 / 2
+        expect(rate).toBeCloseTo(2.5, 6);
+        expect(rateTimeUnit).toBe('min');
+    });
+
+    test('per-frame rate when fpm is null', () => {
+        const { rate, rateTimeUnit } = gravitropism_results({
+            ...base, firstFrameNumber: 0, lastFrameNumber: 10, fpm: null,
+        });
+        expect(rate).toBeCloseTo(0.5, 6);
+        expect(rateTimeUnit).toBe('frame');
+    });
+
+    test('rate is null when the frame span is zero', () => {
+        const { rate } = gravitropism_results({
+            ...base, firstFrameNumber: 4, lastFrameNumber: 4, fpm: 5,
+        });
+        expect(rate).toBeNull();
+    });
+
+    test('rate is null when frame numbers are absent', () => {
+        expect(gravitropism_results({ ...base }).rate).toBeNull();
+    });
+});
+
+describe('circumnutation_results - rate', () => {
+    test('rate uses time between the x-extreme frames', () => {
+        const { maxAmplitude, rate, rateTimeUnit } = circumnutation_results({
+            tipPoints: [
+                { x: 5, y: 0, frame_number: 0 },
+                { x: 1, y: 0, frame_number: 2 },  // min x at frame 2
+                { x: 9, y: 0, frame_number: 8 },  // max x at frame 8
+            ],
+            fpm: null,
+        });
+        expect(maxAmplitude).toBe(8);
+        // elapsed = |8 - 2| = 6 frames; rate = 8 / 6
+        expect(rate).toBeCloseTo(8 / 6, 6);
+        expect(rateTimeUnit).toBe('frame');
+    });
+
+    test('per-minute rate divides the extreme span by fpm', () => {
+        const { rate, rateTimeUnit } = circumnutation_results({
+            tipPoints: [
+                { x: 1, y: 0, frame_number: 0 },
+                { x: 9, y: 0, frame_number: 4 },
+            ],
+            fpm: 2,
+        });
+        // elapsed = 4 frames / 2 fpm = 2 min; rate = 8 / 2
+        expect(rate).toBeCloseTo(4, 6);
+        expect(rateTimeUnit).toBe('min');
+    });
+
+    test('rate is null when the x extremes fall on the same frame', () => {
+        const { rate } = circumnutation_results({
+            tipPoints: [
+                { x: 1, y: 0, frame_number: 3 },
+                { x: 9, y: 0, frame_number: 3 },
+            ],
+            fpm: null,
+        });
+        expect(rate).toBeNull();
+    });
+});

--- a/jstests/canvas_tracer_controller.test.mjs
+++ b/jstests/canvas_tracer_controller.test.mjs
@@ -499,6 +499,29 @@ describe('TracerController inflection point', () => {
     });
 });
 
+// ── capture interval (fpm) parsing (#1056) ───────────────────────────────────
+describe('TracerController fpm parsing', () => {
+    afterEach(() => {
+        resetDollarMock();
+        resetPostMock();
+    });
+
+    test('parses a stored fpm string into a positive number', () => {
+        const tc = new TracerController('div#tc', makeMovieMetadata({ fpm: '30' }), 'k');
+        expect(tc.fpm).toBe(30);
+    });
+
+    test('fpm is null when absent', () => {
+        const tc = new TracerController('div#tc', makeMovieMetadata(), 'k');
+        expect(tc.fpm).toBeNull();
+    });
+
+    test('fpm is null when non-positive', () => {
+        const tc = new TracerController('div#tc', makeMovieMetadata({ fpm: '0' }), 'k');
+        expect(tc.fpm).toBeNull();
+    });
+});
+
 // ── display_results (#986) ───────────────────────────────────────────────────
 describe('display_results', () => {
     const cc = { isFrameInTrim: () => true, fpm: null };
@@ -573,6 +596,21 @@ describe('display_results', () => {
     test('no #result-stats element is a no-op', () => {
         document.body.innerHTML = '';
         expect(() => display_results(cc, framesWithInflection())).not.toThrow();
+    });
+
+    test('Rate is shown per frame when fpm is unset', () => {
+        const el = setupDom('gravitropism');
+        display_results(cc, framesWithInflection());
+        // distance 0.50 mm over 1 frame (frames 0->1) => 0.50 mm/frame
+        expect(el.textContent).toMatch(/Rate: 0\.50 mm\/frame/);
+    });
+
+    test('Rate is shown per minute when fpm is set', () => {
+        const el = setupDom('gravitropism');
+        const ccWithFpm = { isFrameInTrim: () => true, fpm: 2 };
+        display_results(ccWithFpm, framesWithInflection());
+        // 1 frame / 2 fpm = 0.5 min; 0.50 mm / 0.5 min = 1.00 mm/min
+        expect(el.textContent).toMatch(/Rate: 1\.00 mm\/min/);
     });
 });
 

--- a/jstests/canvas_tracer_controller.test.mjs
+++ b/jstests/canvas_tracer_controller.test.mjs
@@ -557,7 +557,7 @@ describe('display_results', () => {
         const el = setupDom('all');
         display_results(cc, framesWithInflection());
         expect(el.textContent).toMatch(/Distance:/);
-        expect(el.textContent).toMatch(/Angle:.*degree/);
+        expect(el.textContent).toMatch(/Angle:.*degrees/);
         expect(el.textContent).toMatch(/Max Amplitude:/);
     });
 

--- a/lambda-resize/src/resize_app/movie_glue.py
+++ b/lambda-resize/src/resize_app/movie_glue.py
@@ -300,6 +300,15 @@ def run_tracing(*, movie_id, frame_start, frame_end=None):
         movie_zipfile_urn = name+"_zipfile"+ext
         write_object_from_path(urn=movie_zipfile_urn, path=movie_zipfile_path)
 
+        # Best-effort snapshot of the capture interval into the traced MP4. DynamoDB remains
+        # authoritative; later edits update only the DB (see docs/Development/MOVIE_METADATA.rst).
+        movie_fpm = movie_record.get("fpm")
+        if movie_fpm:
+            try:
+                mp4_metadata_lib.set_fpm(str(movie_traced_path), movie_fpm)
+            except Exception:  # pylint: disable=broad-exception-caught
+                LOGGER.exception("failed to write fpm metadata to traced movie movie_id=%s", movie_id)
+
         movie_traced_urn = name+"_traced"+ext
         write_object_from_path(urn=movie_traced_urn, path=movie_traced_path)
 

--- a/src/app/constants.py
+++ b/src/app/constants.py
@@ -139,7 +139,7 @@ class C:
         'date_uploaded', 'total_bytes', 'total_frames', 'width', 'height', 'rotation_steps',
         'trim_start_frame', 'trim_end_frame', 'needs_retracing',
     )
-    MOVIE_PROPS_STR = ('fps', 'trackpoint_origin')
+    MOVIE_PROPS_STR = ('fps', 'fpm', 'trackpoint_origin')
 
 
 def configure_local_environment(*, include_tracing_queue=False, include_tracking_queue=False):

--- a/src/app/flask_api.py
+++ b/src/app/flask_api.py
@@ -386,13 +386,19 @@ def api_new_movie():
     if credit_by_name != 1:
         attribution_name = None
 
+    try:
+        fpm = odb.normalize_fpm(get('fpm'))
+    except ValueError as exc:
+        return {'error': True, 'message': str(exc)}
+
     ret[MOVIE_ID] = odb.create_new_movie(user_id=user_id,
                                          course_id=user['primary_course_id'],
                                          title=request.values.get('title'),
                                          description=request.values.get('description'),
                                          research_use=research_use,
                                          credit_by_name=credit_by_name,
-                                         attribution_name=attribution_name)
+                                         attribution_name=attribution_name,
+                                         fpm=fpm)
 
     oname = make_object_name(course_id=odb.course_id_for_movie_id(ret[MOVIE_ID]),
                              movie_id=ret[MOVIE_ID],
@@ -414,7 +420,8 @@ def api_new_movie():
         sha256=movie_data_sha256,
         research_use=_tristate_to_str(research_use),
         credit_by_name=_tristate_to_str(credit_by_name),
-        attribution_name=attribution_name or '')
+        attribution_name=attribution_name or '',
+        fpm=fpm or '')
     return ret
 
 def set_movie_metadata(*, user_id=odb.ROOT_USER_ID, set_movie_id, movie_metadata):
@@ -626,6 +633,23 @@ def api_set_movie_trim():
         )
     except ValueError as exc:
         return jsonify({C.API_KEY_ERROR: True, C.API_KEY_MESSAGE: str(exc)}), 400
+    return jsonify({C.API_KEY_ERROR: False, C.API_KEY_METADATA: metadata})
+
+
+@api_bp.route('/set-movie-fpm', methods=POST)
+def api_set_movie_fpm():
+    """Set the capture interval (frames/minute) for a movie. Owner/admin only."""
+    user_id = get_user_id(allow_demo=False)
+    movie_id = get_movie_id()
+    movie = odb.can_access_movie(user_id=user_id, movie_id=movie_id)
+    try:
+        fpm = odb.normalize_fpm(request.values.get('fpm'))
+    except ValueError as exc:
+        return jsonify({C.API_KEY_ERROR: True, C.API_KEY_MESSAGE: str(exc)}), 400
+    if fpm is None:
+        return jsonify({C.API_KEY_ERROR: True, C.API_KEY_MESSAGE: "fpm is required"}), 400
+    odb.set_metadata(user_id=user_id, set_movie_id=movie[MOVIE_ID], prop=odb.FPM, value=fpm)
+    metadata = odb.get_movie_metadata(movie_id=movie[MOVIE_ID])
     return jsonify({C.API_KEY_ERROR: False, C.API_KEY_METADATA: metadata})
 
 

--- a/src/app/mp4_metadata_lib.py
+++ b/src/app/mp4_metadata_lib.py
@@ -7,9 +7,13 @@ import io
 from typing import Optional
 
 from PIL import Image
-from mutagen.mp4 import MP4, MP4Tags
+from mutagen.mp4 import MP4, MP4Tags, MP4FreeForm
 
 COMMENT_ATOM = "\xa9cmt"
+# Dedicated freeform atom for the capture interval (frames/minute), kept separate from the
+# research-attribution comment atom. DynamoDB remains authoritative; this is a best-effort
+# snapshot written when the movie is processed (see docs/Development/MOVIE_METADATA.rst).
+FPM_ATOM = "----:com.planttracer:capture_fpm"
 
 RESEARCH_PROHIBITED = "research use prohibited"
 RESEARCH_ANONYMOUS = "research use allowed (no credit required)"
@@ -57,6 +61,33 @@ def set_comment(path: str, comment: str) -> None:
         mp4.add_tags()
     assert isinstance(mp4.tags, MP4Tags)
     mp4.tags[COMMENT_ATOM] = [comment]
+    mp4.save()
+
+
+def get_fpm(path: str) -> str | None:
+    """Read the capture-interval (frames/minute) atom from an MP4/MOV file. None if missing/error."""
+    try:
+        mp4 = MP4(path)
+        if mp4.tags is None:
+            return None
+        values = mp4.tags.get(FPM_ATOM, [])
+        if not values:
+            return None
+        part = values[0]
+        if isinstance(part, bytes):
+            return part.decode("utf-8", "replace")
+        return str(part)
+    except Exception:  # pylint: disable=broad-exception-caught
+        return None
+
+
+def set_fpm(path: str, fpm: str) -> None:
+    """Set the capture-interval (frames/minute) atom and save the file."""
+    mp4 = MP4(path)
+    if mp4.tags is None:
+        mp4.add_tags()
+    assert isinstance(mp4.tags, MP4Tags)
+    mp4.tags[FPM_ATOM] = [MP4FreeForm(str(fpm).encode("utf-8"))]
     mp4.save()
 
 

--- a/src/app/odb.py
+++ b/src/app/odb.py
@@ -95,6 +95,7 @@ CREATED_AT = 'created_at'
 EMAIL = 'email'
 NAME = 'name'
 FPS = 'fps'
+FPM = 'fpm'
 WIDTH = 'width'
 HEIGHT = 'height'
 TRACKPOINT_ORIGIN = 'trackpoint_origin'
@@ -1373,6 +1374,31 @@ def get_movie_metadata(*, movie_id, get_last_frame_tracked=False):
     return movie
 
 
+FPM_MAX = 6000  # soft upper bound to catch typos (frames/minute)
+
+
+def normalize_fpm(raw):
+    """Normalize a user-supplied capture interval (frames/minute) for storage.
+
+    Returns a trimmed string for a valid positive number, or None when blank/absent.
+    Raises ValueError when the value is non-numeric, not positive, or above FPM_MAX.
+    """
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if text == '':
+        return None
+    try:
+        value = float(text)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("fpm must be a number") from exc
+    if value <= 0:
+        raise ValueError("fpm must be greater than 0")
+    if value > FPM_MAX:
+        raise ValueError(f"fpm must be <= {FPM_MAX}")
+    return text
+
+
 def _movie_total_frames(movie: dict) -> int | None:
     total_frames = movie.get(TOTAL_FRAMES)
     if total_frames is None:
@@ -1490,7 +1516,7 @@ def can_access_movie(*, user_id, movie_id):
     raise UnauthorizedUser(f"user {user_id} attempted to access movie {movie_id}")
 
 def create_new_movie(*, user_id, course_id=None, title=None, description=None, orig_movie=None,
-                     research_use=None, credit_by_name=None, attribution_name=None):
+                     research_use=None, credit_by_name=None, attribution_name=None, fpm=None):
     """
     Creates an entry for a new movie and returns the movie_id. The movie content must be uploaded separately.
 
@@ -1501,6 +1527,7 @@ def create_new_movie(*, user_id, course_id=None, title=None, description=None, o
     :param research_use: - 1 if movie may be used in research, 0 if not, None if not yet answered
     :param credit_by_name: - 1 if user wants credit by name, 0 if anonymous, None if not yet answered
     :param attribution_name: - name for attribution when credit_by_name is 1, else None
+    :param fpm: - capture interval in frames/minute (time-lapse), as a string, or None
     :return: movie_id of the created movie
 
     """
@@ -1526,6 +1553,7 @@ def create_new_movie(*, user_id, course_id=None, title=None, description=None, o
                     DATE_UPLOADED: int(time.time()),
                     TOTAL_FRAMES: None,
                     TOTAL_BYTES: None,
+                    FPM: fpm,
                     VERSION: 0,
                     TRACKPOINT_ORIGIN: TRACKPOINT_ORIGIN_BOTTOM_LEFT,
                     RESEARCH_USE: research_use,
@@ -2197,6 +2225,7 @@ SET_MOVIE_METADATA = {
     DESCRIPTION: 'update movies set description=%s where id=%s and (@is_owner or @is_admin)',
     MOVIE_STATUS: 'update movies set status=%s where id=%s and (@is_owner or @is_admin)',
     FPS: 'update movies set fps=%s where id=%s and (@is_owner or @is_admin)',
+    FPM: 'update movies set fpm=%s where id=%s and (@is_owner or @is_admin)',
     WIDTH: 'update movies set width=%s where id=%s and (@is_owner or @is_admin)',
     HEIGHT: 'update movies set height=%s where id=%s and (@is_owner or @is_admin)',
     TOTAL_FRAMES: 'update movies set total_frames=%s where id=%s and (@is_owner or @is_admin)',

--- a/src/app/s3_presigned.py
+++ b/src/app/s3_presigned.py
@@ -115,9 +115,11 @@ def make_signed_url(*,urn,operation=C.GET, expires=3600):
         ExpiresIn=expires)
 
 def make_presigned_post(*, urn, maxsize=C.MAX_FILE_UPLOAD, mime_type='video/mp4', sha256=None, expires=3600,
-                        research_use='not-answered', credit_by_name='not-answered', attribution_name=''):
+                        research_use='not-answered', credit_by_name='not-answered', attribution_name='',
+                        fpm=''):
     """Returns a dictionary with 'url' and 'fields'.
-    research_use, credit_by_name, attribution_name are included in the signature and set as S3 object metadata.
+    research_use, credit_by_name, attribution_name, and fpm (capture interval, frames/minute) are included in
+    the signature and set as S3 object metadata.
     Uses the bucket's region so the presigned URL is regional and S3 does not 307-redirect (avoids connection
     reset in the browser when POST body is not re-sent on redirect).
     """
@@ -138,12 +140,15 @@ def make_presigned_post(*, urn, maxsize=C.MAX_FILE_UPLOAD, mime_type='video/mp4'
     meta_research = 'x-amz-meta-research-use'
     meta_credit = 'x-amz-meta-credit-by-name'
     meta_attribution = 'x-amz-meta-attribution-name'
+    meta_fpm = 'x-amz-meta-fpm'
     attribution_safe = (attribution_name or '')[:256]
+    fpm_safe = (fpm or '')[:32]
     fields = {
         'Content-Type': mime_type,
         meta_research: research_use,
         meta_credit: credit_by_name,
         meta_attribution: attribution_safe,
+        meta_fpm: fpm_safe,
     }
     conditions = [
         {"Content-Type": mime_type},
@@ -151,6 +156,7 @@ def make_presigned_post(*, urn, maxsize=C.MAX_FILE_UPLOAD, mime_type='video/mp4'
         {meta_research: research_use},
         {meta_credit: credit_by_name},
         {meta_attribution: attribution_safe},
+        {meta_fpm: fpm_safe},
     ]
     return client.generate_presigned_post(
         Bucket=bucket,

--- a/src/app/schema.py
+++ b/src/app/schema.py
@@ -94,7 +94,8 @@ class Movie(BaseModel):
     deleted: Annotated[int, Field(ge=0, le=1)]
     date_uploaded: int | None = None
     orig_movie: str | None = None
-    fps: str | None = None  # otherwise we get roundoff errors
+    fps: str | None = None  # encoded playback frame rate; string to avoid roundoff errors
+    fpm: str | None = None  # capture interval in frames/minute (time-lapse); string to avoid roundoff
     width: Annotated[int | None, Field(ge=0, le=10000)] = None
     height: Annotated[int | None, Field(ge=0, le=10000)] = None
     trackpoint_origin: Literal["bottom-left"] | None = None

--- a/src/app/static/analysis_results.mjs
+++ b/src/app/static/analysis_results.mjs
@@ -16,8 +16,10 @@
  *     Inflection Point pivot, via the law of cosines).
  *   - Circumnutation: Max Amplitude (horizontal x-range of the tip over all frames).
  *
- * Rate (displacement per unit time) is intentionally NOT computed here yet; the
- * frame->time conversion is unresolved (see #986) and tracked as a follow-up.
+ * Rate (displacement per unit time) is computed from the capture interval `fpm`
+ * (frames/minute, see #1056): elapsed_time(min) = frame_span / fpm. When fpm is not set,
+ * Rate is expressed per frame instead of per minute (the `rateTimeUnit` field is
+ * 'min' or 'frame' accordingly). See #1053.
  *
  * All inputs are points of the form {x, y} in a single consistent coordinate space.
  * `scale` converts pixels to physical units (mm/pixel); pass 1 for pixels. Distance and
@@ -31,6 +33,33 @@ function distance_between(a, b) {
 
 function is_point(p) {
     return p && Number.isFinite(Number(p.x)) && Number.isFinite(Number(p.y));
+}
+
+function rate_time_unit(fpm) {
+    return (fpm != null && Number(fpm) > 0) ? 'min' : 'frame';
+}
+
+function frame_span(a, b) {
+    if (a == null || b == null || !Number.isFinite(Number(a)) || !Number.isFinite(Number(b))) {
+        return null;
+    }
+    return Math.abs(Number(b) - Number(a));
+}
+
+/*
+ * Rate of a magnitude over an elapsed frame span. With a positive fpm, the span is
+ * converted to minutes (span / fpm); otherwise the span stays in frames. Returns
+ * { rate, rateTimeUnit } where rate is null when it cannot be computed (no span, or a
+ * zero-length span — e.g. the x extremes fall on the same frame).
+ */
+function elapsed_rate(magnitude, elapsedFrames, fpm) {
+    const rateTimeUnit = rate_time_unit(fpm);
+    if (magnitude == null || elapsedFrames == null) {
+        return { rate: null, rateTimeUnit };
+    }
+    const elapsed = rateTimeUnit === 'min' ? elapsedFrames / Number(fpm) : elapsedFrames;
+    const rate = elapsed > 0 ? magnitude / elapsed : null;
+    return { rate, rateTimeUnit };
 }
 
 /*
@@ -47,13 +76,15 @@ function is_point(p) {
  * point, making the triangle undefined).
  */
 function gravitropism_results({ firstTip, lastTip, firstInflection = null,
-                                lastInflection = null, scale = 1 } = {}) {
+                                lastInflection = null, scale = 1,
+                                firstFrameNumber = null, lastFrameNumber = null, fpm = null } = {}) {
     if (!is_point(firstTip) || !is_point(lastTip)) {
-        return { distance: null, angle: null };
+        return { distance: null, angle: null, rate: null, rateTimeUnit: rate_time_unit(fpm) };
     }
     const distance = distance_between(firstTip, lastTip) * scale;
     const angle = inflection_angle(firstTip, lastTip, firstInflection, lastInflection);
-    return { distance, angle };
+    const { rate, rateTimeUnit } = elapsed_rate(distance, frame_span(firstFrameNumber, lastFrameNumber), fpm);
+    return { distance, angle, rate, rateTimeUnit };
 }
 
 /*
@@ -81,18 +112,33 @@ function inflection_angle(firstTip, lastTip, firstInflection, lastInflection) {
 /*
  * Circumnutation results.
  *
- * @param {Array}  tipPoints  tip positions {x, y} across all (trimmed) frames
+ * @param {Array}  tipPoints  tip positions {x, y, frame_number} across all (trimmed) frames
  * @param {number} scale      mm/pixel (default 1 = pixels)
+ * @param {number} fpm        capture interval in frames/minute (null/0 => Rate per frame)
  *
- * Returns { maxAmplitude } = (max x - min x) * scale, or null when there are no points.
+ * Returns { maxAmplitude, rate, rateTimeUnit }. maxAmplitude = (max x - min x) * scale.
+ * Rate = maxAmplitude / elapsed time between the x-extreme frames (legacy semantics); it is
+ * null when there are no points or the extremes fall on the same frame.
  */
-function circumnutation_results({ tipPoints = [], scale = 1 } = {}) {
-    const xs = (tipPoints || []).filter(is_point).map(p => Number(p.x));
-    if (xs.length === 0) {
-        return { maxAmplitude: null };
+function circumnutation_results({ tipPoints = [], scale = 1, fpm = null } = {}) {
+    const points = (tipPoints || []).filter(is_point);
+    if (points.length === 0) {
+        return { maxAmplitude: null, rate: null, rateTimeUnit: rate_time_unit(fpm) };
     }
-    const maxAmplitude = (Math.max(...xs) - Math.min(...xs)) * scale;
-    return { maxAmplitude };
+    let minPoint = points[0];
+    let maxPoint = points[0];
+    for (const point of points) {
+        if (Number(point.x) < Number(minPoint.x)) {
+            minPoint = point;
+        }
+        if (Number(point.x) > Number(maxPoint.x)) {
+            maxPoint = point;
+        }
+    }
+    const maxAmplitude = (Number(maxPoint.x) - Number(minPoint.x)) * scale;
+    const { rate, rateTimeUnit } = elapsed_rate(
+        maxAmplitude, frame_span(minPoint.frame_number, maxPoint.frame_number), fpm);
+    return { maxAmplitude, rate, rateTimeUnit };
 }
 
 export { gravitropism_results, circumnutation_results, inflection_angle, distance_between };

--- a/src/app/static/canvas_tracer_controller.mjs
+++ b/src/app/static/canvas_tracer_controller.mjs
@@ -1978,7 +1978,7 @@ function display_results(cc, frames) {
             lines.push(`Rate: ${format_measure(rate)} ${units}/${rateTimeUnit}`);
         }
         if (angle != null) {
-            lines.push(`Angle: ${format_measure(angle)} degree`);
+            lines.push(`Angle: ${format_measure(angle)} degrees`);
         } else if (mode === 'gravitropism' && !inflectionLabel) {
             lines.push('Add an Inflection Point marker to compute the bending angle.');
         }

--- a/src/app/static/canvas_tracer_controller.mjs
+++ b/src/app/static/canvas_tracer_controller.mjs
@@ -125,6 +125,11 @@ function get_ruler_size(str) {
     return match ? parseInt(match[1], 10) : null;
 }
 
+// Parse a stored capture interval (frames/minute) to a positive number, or null when unset/invalid.
+function parse_fpm(value) {
+    return (value != null && Number(value) > 0) ? Number(value) : null;
+}
+
 function is_ruler_marker_label(label) {
     return typeof label === 'string' && get_ruler_size(label) !== null;
 }
@@ -209,6 +214,8 @@ class TracerController extends MovieController {
         this.api_key = api_key;
         this.movie_id = movie_metadata.movie_id;
         this.movie_rotation = (movie_metadata.rotation == null) ? 0 : movie_metadata.rotation;
+        // Capture interval (frames/minute); null when unset => graphs/Rate fall back to frames.
+        this.fpm = parse_fpm(movie_metadata.fpm);
         this.trim_start_frame_missing = movie_metadata[TRIM_START_FRAME] == null;
         this.trim_end_frame_missing = movie_metadata[TRIM_END_FRAME] == null;
         // Last frame index that has trackpoints (from API). -1 = none traced yet.
@@ -286,6 +293,14 @@ class TracerController extends MovieController {
         this.trim_set_start_button.off('click').on('click', () => { this.set_trim_bound(TRIM_START_FRAME); });
         this.trim_set_end_button.off('click').on('click', () => { this.set_trim_bound(TRIM_END_FRAME); });
 
+        // Capture interval (frames/minute) input — edits update the DB only (no retrace).
+        this.fpm_input = $(this.div_selector + " input.fpm_input");
+        this.fpm_set_button = $(this.div_selector + " input.fpm_set_button");
+        if (this.fpm != null) {
+            this.fpm_input.val(this.fpm);
+        }
+        this.fpm_set_button.off('click').on('click', () => { this.set_fpm(); });
+
         $(this.div_selector + " span.total-frames-span").text(this.total_frames);
 
         this.refreshTrackButtonState();
@@ -316,6 +331,31 @@ class TracerController extends MovieController {
             throw new Error(`${prop} must be an integer`);
         }
         return parsed;
+    }
+
+    // POST the capture interval (frames/minute) and refresh graphs/results. No retrace needed.
+    set_fpm() {
+        if (demo_mode) {
+            $('#demo-popup').fadeIn(300);
+            return;
+        }
+        const params = {
+            api_key: this.api_key,
+            movie_id: this.movie_id,
+            fpm: this.fpm_input.val(),
+        };
+        $.post(`${API_BASE}api/set-movie-fpm`, params)
+            .done((data) => {
+                if (data.error) {
+                    alert(data.message);
+                    return;
+                }
+                this.movie_metadata = {...this.movie_metadata, ...data.metadata};
+                this.fpm = parse_fpm(this.movie_metadata.fpm);
+                this.refreshVisibleGraphs();
+                this.refreshResults();
+            })
+            .fail(() => { alert('Failed to set the capture interval.'); });
     }
 
     ensure_trim_defaults() {
@@ -1906,18 +1946,36 @@ function display_results(cc, frames) {
 
     const tipLabel = result_tip_label(graphFrames);
     const inflectionLabel = result_inflection_label(graphFrames);
+    const fpm = cc ? cc.fpm : null;
+    // Tracked-tip positions paired with their frame numbers, in trimmed order.
+    const tipEntries = tipLabel
+        ? graphFrames
+            .map((frame, frameIndex) => {
+                const marker = marker_for_label(frame.markers, tipLabel);
+                return marker ? { marker, frameNumber: graph_frame_number(frame, marker, frameIndex) } : null;
+            })
+            .filter(entry => entry)
+        : [];
+    const firstTipEntry = tipEntries[0] || null;
+    const lastTipEntry = tipEntries.length ? tipEntries[tipEntries.length - 1] : null;
     const lines = [];
 
     if (mode === 'all' || mode === 'gravitropism') {
-        const { distance, angle } = gravitropism_results({
-            firstTip: tipLabel ? first_marker_for_label(graphFrames, tipLabel) : null,
-            lastTip: tipLabel ? last_marker_for_label(graphFrames, tipLabel) : null,
+        const { distance, angle, rate, rateTimeUnit } = gravitropism_results({
+            firstTip: firstTipEntry ? firstTipEntry.marker : null,
+            lastTip: lastTipEntry ? lastTipEntry.marker : null,
             firstInflection: inflectionLabel ? first_marker_for_label(graphFrames, inflectionLabel) : null,
             lastInflection: inflectionLabel ? last_marker_for_label(graphFrames, inflectionLabel) : null,
             scale,
+            firstFrameNumber: firstTipEntry ? firstTipEntry.frameNumber : null,
+            lastFrameNumber: lastTipEntry ? lastTipEntry.frameNumber : null,
+            fpm,
         });
         if (distance != null) {
             lines.push(`Distance: ${format_measure(distance)} ${units}`);
+        }
+        if (rate != null) {
+            lines.push(`Rate: ${format_measure(rate)} ${units}/${rateTimeUnit}`);
         }
         if (angle != null) {
             lines.push(`Angle: ${format_measure(angle)} degree`);
@@ -1927,12 +1985,15 @@ function display_results(cc, frames) {
     }
 
     if (mode === 'all' || mode === 'circumnutation') {
-        const tipPoints = tipLabel
-            ? graphFrames.map(frame => marker_for_label(frame.markers, tipLabel)).filter(marker => marker)
-            : [];
-        const { maxAmplitude } = circumnutation_results({ tipPoints, scale });
+        const tipPoints = tipEntries.map(entry => ({
+            x: entry.marker.x, y: entry.marker.y, frame_number: entry.frameNumber,
+        }));
+        const { maxAmplitude, rate, rateTimeUnit } = circumnutation_results({ tipPoints, scale, fpm });
         if (maxAmplitude != null) {
             lines.push(`Max Amplitude: ${format_measure(maxAmplitude)} ${units}`);
+        }
+        if (rate != null) {
+            lines.push(`Rate: ${format_measure(rate)} ${units}/${rateTimeUnit}`);
         }
     }
 

--- a/src/app/static/planttracer.js
+++ b/src/app/static/planttracer.js
@@ -200,7 +200,7 @@ async function startLambdaProcessing(movie_id) {
  *
  * Presigned post is provided by the /api/new-movie call (see below)
  */
-async function upload_movie_post(movie_title, description, movieFile, research_use, credit_by_name, attribution_name)
+async function upload_movie_post(movie_title, description, movieFile, research_use, credit_by_name, attribution_name, fpm)
 {
   // If Lambda is configured, ensure it is healthy before starting upload
   if (typeof LAMBDA_API_BASE !== 'undefined' && LAMBDA_API_BASE) {
@@ -221,6 +221,7 @@ async function upload_movie_post(movie_title, description, movieFile, research_u
   if (research_use !== null) { formData.append("research_use", research_use); }
   if (credit_by_name !== null) { formData.append("credit_by_name", credit_by_name); }
   formData.append("attribution_name", attribution_name || "");
+  if (fpm) { formData.append("fpm", fpm); }
   const r = await fetch(`${API_BASE}api/new-movie`, { method:"POST", body:formData});
   const obj = await r.json();
   console.log('new-movie obj=',obj);
@@ -354,6 +355,7 @@ function upload_movie()
   const research_use = $('input[name="research_use"]:checked').val() || null;   // '1', '0', or null
   const credit_by_name = $('input[name="credit_by_name"]:checked').val() || null; // '1', '0', or null
   const attribution_name = (research_use === '1' && credit_by_name === '1') ? ($('#attribution-name').val() || '').trim() : '';
+  const fpm = ($('#movie-fpm').val() || '').trim();
 
   if (movie_title.length < 3) {
     $('#message').html('<b>Movie title must be at least 3 characters long');
@@ -379,7 +381,7 @@ function upload_movie()
   $('#upload-button').prop('disabled', true);
   $('#upload_message').html(`Uploading movie ...`);
 
-  upload_movie_post(movie_title, description, movieFile, research_use, credit_by_name, attribution_name);
+  upload_movie_post(movie_title, description, movieFile, research_use, credit_by_name, attribution_name, fpm);
 }
 
 async function _get_movie_metadata(movie_id){

--- a/src/app/templates/analyze.html
+++ b/src/app/templates/analyze.html
@@ -81,9 +81,6 @@
     if no Apex marker is present.
   </p>
 
-  <p>
-    This version of PlantTracer does not calculate or display the time elapsed in the uploaded videos. Please refer to the <a href="https://plant-tracer.github.io/webapp/UserTutorial.html">Help</a> for an example of how to calculate time in seconds from the frame values provided.
-  </p>
 </div>
 
 <script type='module'>

--- a/src/app/templates/tracer_app.html
+++ b/src/app/templates/tracer_app.html
@@ -50,6 +50,13 @@
           <input type='button' value='Set end' class='trim_set_end_button pure-button'>
         </span>
       </div>
+      <div class='fpm-control-row nodemo'>
+        <label for='fpm-input-id' title='Time-lapse capture interval; used to report results per minute.'>
+          Capture interval (frames/minute):
+        </label>
+        <input id='fpm-input-id' class='fpm_input' type='number' min='0' step='any' size='8'>
+        <input type='button' value='Set' class='fpm_set_button pure-button'>
+      </div>
     </form>
   </div>
   <!-- Control start -->

--- a/src/app/templates/upload.html
+++ b/src/app/templates/upload.html
@@ -32,6 +32,11 @@
         <span class="pure-form-message-inline">required (at least 3 characters)</span>
       </div>
       <div class='pure-control-group'>
+        <label for='movie-fpm'>Capture interval (frames/minute):</label>
+        <input type='number' id='movie-fpm' name='fpm' min='0' step='any'>
+        <span class="pure-form-message-inline">optional (time-lapse rate; can be set later)</span>
+      </div>
+      <div class='pure-control-group'>
         <label for='movie-file'>Select movie to upload:</label>
         <input id='movie-file' type="file" onchange='check_upload_metadata()'>
         <span class="pure-form-message-inline">required</span>

--- a/tests/movie_test.py
+++ b/tests/movie_test.py
@@ -178,6 +178,38 @@ def test_movie_upload_presigned_post(client, new_course, local_s3):
     logger.info("PURGE MOVIE %s",res['movie_id'])
 
 
+def test_new_movie_stores_fpm_and_signs_metadata(client, new_course, local_s3):
+    """new-movie with fpm stores it on the movie and includes x-amz-meta-fpm in the presigned post."""
+    api_key = copy.copy(new_course)[API_KEY]
+    with open(TEST_PLANTMOVIE_PATH, "rb") as f:
+        movie_data_sha256 = s3_presigned.sha256_hash(f.read())
+    resp = client.post('/api/new-movie',
+                       data={'api_key': api_key,
+                             "title": f'fpm-movie {uuid.uuid4()}',
+                             "description": "fpm movie",
+                             "movie_data_sha256": movie_data_sha256,
+                             "fpm": "30"})
+    res = resp.get_json()
+    assert res['error'] is False
+    assert odb.get_movie(movie_id=res['movie_id'])[odb.FPM] == "30"
+    assert res['presigned_post']['fields'].get('x-amz-meta-fpm') == "30"
+    odb_movie_data.purge_movie(movie_id=res['movie_id'])
+
+
+def test_new_movie_rejects_invalid_fpm(client, new_course):
+    """new-movie with an invalid fpm returns an error and does not create the movie."""
+    api_key = copy.copy(new_course)[API_KEY]
+    resp = client.post('/api/new-movie',
+                       data={'api_key': api_key,
+                             "title": f'bad-fpm {uuid.uuid4()}',
+                             "description": "bad fpm",
+                             "movie_data_sha256": "a" * 64,
+                             "fpm": "-5"})
+    res = resp.get_json()
+    assert res['error'] is True
+    assert res['message'] == "fpm must be greater than 0"
+
+
 def test_movie_update_metadata(client, new_movie):
     """try updating the metadata, and making sure some updates fail."""
     cfg = copy.copy(new_movie)
@@ -702,3 +734,46 @@ def test_set_movie_trim_returns_validation_error(client, new_movie):
 
     assert resp.status_code == 400
     assert resp.get_json()['message'] == "trim_end_frame must be < total_frames"
+
+
+def test_set_movie_fpm_persists_value(client, new_movie):
+    api_key = new_movie[API_KEY]
+    movie_id = new_movie[MOVIE_ID]
+
+    resp = client.post('/api/set-movie-fpm', data={
+        'api_key': api_key,
+        'movie_id': movie_id,
+        'fpm': '30',
+    })
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body['error'] is False
+    assert body['metadata'][odb.FPM] == '30'
+    assert odb.get_movie(movie_id=movie_id)[odb.FPM] == '30'
+
+
+def test_set_movie_fpm_accepts_fractional(client, new_movie):
+    resp = client.post('/api/set-movie-fpm', data={
+        'api_key': new_movie[API_KEY],
+        'movie_id': new_movie[MOVIE_ID],
+        'fpm': '0.5',
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()['metadata'][odb.FPM] == '0.5'
+
+
+def test_set_movie_fpm_rejects_invalid(client, new_movie):
+    api_key = new_movie[API_KEY]
+    movie_id = new_movie[MOVIE_ID]
+
+    resp = client.post('/api/set-movie-fpm', data={'api_key': api_key, 'movie_id': movie_id, 'fpm': 'abc'})
+    assert resp.status_code == 400
+    assert resp.get_json()['message'] == "fpm must be a number"
+
+    resp = client.post('/api/set-movie-fpm', data={'api_key': api_key, 'movie_id': movie_id, 'fpm': '0'})
+    assert resp.status_code == 400
+    assert resp.get_json()['message'] == "fpm must be greater than 0"
+
+    resp = client.post('/api/set-movie-fpm', data={'api_key': api_key, 'movie_id': movie_id})
+    assert resp.status_code == 400
+    assert resp.get_json()['message'] == "fpm is required"

--- a/tests/mp4_metadata_test.py
+++ b/tests/mp4_metadata_test.py
@@ -118,6 +118,21 @@ def test_build_comment_credit():
     assert got == "research use allowed; credit Alyssa P. Hacker"
 
 
+def test_fpm_roundtrip(sample_mp4):
+    """set_fpm writes a freeform atom that get_fpm reads back; absent => None."""
+    assert mp4_metadata_lib.get_fpm(sample_mp4) is None
+    mp4_metadata_lib.set_fpm(sample_mp4, "30")
+    assert mp4_metadata_lib.get_fpm(sample_mp4) == "30"
+
+
+def test_fpm_atom_separate_from_comment(sample_mp4):
+    """The fpm atom and the research-attribution comment do not clobber each other."""
+    mp4_metadata_lib.set_comment(sample_mp4, "research use prohibited")
+    mp4_metadata_lib.set_fpm(sample_mp4, "0.5")
+    assert mp4_metadata_lib.get_fpm(sample_mp4) == "0.5"
+    assert _get_comment(sample_mp4) == "research use prohibited"
+
+
 def test_add_comment_to_jpeg_roundtrip():
     """add_comment_to_jpeg adds a COM segment that can be read back with Pillow."""
     # Minimal 1x1 RGB JPEG bytes (no comment)

--- a/tests/mp4_metadata_test.py
+++ b/tests/mp4_metadata_test.py
@@ -133,6 +133,30 @@ def test_fpm_atom_separate_from_comment(sample_mp4):
     assert _get_comment(sample_mp4) == "research use prohibited"
 
 
+def test_get_fpm_missing_or_invalid_file_returns_none(tmp_path):
+    """get_fpm is best-effort and returns None for missing or invalid files."""
+    assert mp4_metadata_lib.get_fpm(str(tmp_path / "missing.mp4")) is None
+
+    invalid_mp4 = tmp_path / "invalid.mp4"
+    invalid_mp4.write_text("not an mp4", encoding="utf-8")
+    assert mp4_metadata_lib.get_fpm(str(invalid_mp4)) is None
+
+
+def test_set_fpm_overwrites_existing_value(sample_mp4):
+    """set_fpm replaces the previous capture interval atom."""
+    mp4_metadata_lib.set_fpm(sample_mp4, "30")
+    mp4_metadata_lib.set_fpm(sample_mp4, "0.5")
+
+    assert mp4_metadata_lib.get_fpm(sample_mp4) == "0.5"
+
+
+def test_set_fpm_stores_non_string_values_as_text(sample_mp4):
+    """set_fpm coerces values to text before writing the freeform atom."""
+    mp4_metadata_lib.set_fpm(sample_mp4, 24)
+
+    assert mp4_metadata_lib.get_fpm(sample_mp4) == "24"
+
+
 def test_add_comment_to_jpeg_roundtrip():
     """add_comment_to_jpeg adds a COM segment that can be read back with Pillow."""
     # Minimal 1x1 RGB JPEG bytes (no comment)

--- a/tests/odb_test.py
+++ b/tests/odb_test.py
@@ -652,3 +652,47 @@ def test_delete_user_api_keys_pagination(local_ddb, mocker):
     ddbo.delete_user(user_id)
     assert user_id not in odb.course_enrollments(course_id=course_id)
     odb.delete_course(course_id=course_id)
+
+
+def test_normalize_fpm_valid_values():
+    assert odb.normalize_fpm(None) is None
+    assert odb.normalize_fpm('') is None
+    assert odb.normalize_fpm('   ') is None
+    assert odb.normalize_fpm('30') == '30'
+    assert odb.normalize_fpm('  0.5 ') == '0.5'
+
+
+def test_normalize_fpm_rejects_invalid():
+    with pytest.raises(ValueError, match="fpm must be a number"):
+        odb.normalize_fpm('abc')
+    with pytest.raises(ValueError, match="fpm must be greater than 0"):
+        odb.normalize_fpm('0')
+    with pytest.raises(ValueError, match="fpm must be greater than 0"):
+        odb.normalize_fpm('-1')
+    with pytest.raises(ValueError, match="fpm must be <="):
+        odb.normalize_fpm('99999')
+
+
+def test_create_new_movie_stores_fpm(local_ddb):
+    course_id = f"fpm-course-{rand8()}"
+    local_ddb.put_course({
+        COURSE_ID: course_id,
+        'course_name': 'FPM Course',
+        'course_key': f"k-{uuid.uuid4().hex[:12]}",
+        'admins_for_course': [],
+        'max_enrollment': 10,
+    })
+    user_id = odb.new_user_id()
+    local_ddb.put_user({
+        USER_ID: user_id,
+        'email': f"fpm-{uuid.uuid4().hex[:8]}@example.com",
+        'user_name': 'FPM User',
+        'created': int(time.time()),
+        'enabled': 1,
+        'admin_for_courses': [],
+        'courses': [course_id],
+        'primary_course_id': course_id,
+        'primary_course_name': 'FPM Course',
+    })
+    movie_id = odb.create_new_movie(user_id=user_id, course_id=course_id, title='t', description='d', fpm='20')
+    assert odb.get_movie(movie_id=movie_id)[odb.FPM] == '20'


### PR DESCRIPTION
fixes #1053
fixes #1056
fixes #1060

## Summary
- Add frames-per-minute capture interval support through upload, metadata, persistence, API responses, and analysis results.
- Display Rate statistics per minute when capture interval is available, otherwise per frame.
- Update Analyze/User Tutorial wording for current time conversion behavior and pluralize Angle units to "degrees".

## Verification
- poetry run sphinx-build -W --keep-going -b html docs docs/_build/html
- make eslint
- NODE_PATH=src/app/static npm test -- canvas_tracer_controller.test.mjs --watchman=false