### PR TITLE
Bump version to 0.9.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "webapp"
-version = "0.9.7.6.2"
+version = "0.9.8"
 description = "PlantTracer webapp"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/src/app/constants.py
+++ b/src/app/constants.py
@@ -7,7 +7,7 @@ Constants are created in classes so we can import the class and don't have to im
 import logging
 import os
 
-__version__ = '0.9.7.6.2'
+__version__ = '0.9.8'
 
 # these aren't strictly constants...
 log_level = os.getenv("LOG_LEVEL","INFO").upper()


### PR DESCRIPTION
refs #1063

Bump `__version__` and `pyproject.toml` version to 0.9.8 ahead of tagging `ver-0.9.8`. (Also corrects the version constant, which was left at 0.9.7.6.2 by the off-process 0.9.7.6.3 release.)

`make check` passes (pylint 10.00, pytest 177 passed/1 skipped, jest 429).