### PR TITLE
refs #1069: bump version to 0.9.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "webapp"
-version = "0.9.8"
+version = "0.9.8.1"
 description = "PlantTracer webapp"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/src/app/constants.py
+++ b/src/app/constants.py
@@ -7,7 +7,7 @@ Constants are created in classes so we can import the class and don't have to im
 import logging
 import os
 
-__version__ = '0.9.8'
+__version__ = '0.9.8.1'
 
 # these aren't strictly constants...
 log_level = os.getenv("LOG_LEVEL","INFO").upper()


### PR DESCRIPTION
refs #1069

Bumps version to 0.9.8.1 for the June30-2026 milestone release.

- `src/app/constants.py`: `__version__ = '0.9.8.1'`
- `pyproject.toml`: `version = "0.9.8.1"`

`make check` passed locally (186 Python tests, 429 JS tests, lint clean).