### PR TITLE
Add ver-0.9.8.2 to ReleaseHistory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ After creating the GitHub release, open a PR to update `docs/ReleaseHistory.rst`
 1. Add a row to the release table at the top of the file (Name, Version, Date, link to the GitHub release tag).
 2. Add a summary section for the new release (above the previous release's summary), with a bullet per significant change derived from the release notes. The act of updating ReleaseHistory itself need not be mentioned in the summary.
 
-This PR should close the tagging Issue (e.g. `fixes #N`) so that merging the PR automatically closes it. It does **not** need its own separate GitHub Issue.
+The PR title should be `Add ver-X.Y.Z to ReleaseHistory` (no issue number in the title). The PR body should close the tagging Issue (e.g. `fixes #N`) so that merging the PR automatically closes it. It does **not** need its own separate GitHub Issue.
 
 ## Tagging a Release
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ After creating the GitHub release, open a PR to update `docs/ReleaseHistory.rst`
 1. Add a row to the release table at the top of the file (Name, Version, Date, link to the GitHub release tag).
 2. Add a summary section for the new release (above the previous release's summary), with a bullet per significant change derived from the release notes. The act of updating ReleaseHistory itself need not be mentioned in the summary.
 
-This PR should reference the tagging Issue (e.g. `refs #N`) so the work is traceable. It does **not** need its own separate GitHub Issue.
+This PR should close the tagging Issue (e.g. `fixes #N`) so that merging the PR automatically closes it. It does **not** need its own separate GitHub Issue.
 
 ## Tagging a Release
 

--- a/docs/ReleaseHistory.rst
+++ b/docs/ReleaseHistory.rst
@@ -67,9 +67,20 @@ Release History
      - 0.9.8.1
      - June 23, 2026
      - `Closed Issues <https://github.com/Plant-Tracer/webapp/releases/tag/ver-0.9.8.1>`__
+   * - Jun-29-2026
+     - 0.9.8.2
+     - June 29, 2026
+     - `Closed Issues <https://github.com/Plant-Tracer/webapp/releases/tag/ver-0.9.8.2>`__
 
 Release Notes
 -------------
+
+0.9.8.2 Summary
+***************
+    * Documentation: new Calculation Reference page covering gravitropism and circumnutation statistics formulas
+    * Documentation: styled to match the Plant Tracer site fonts and colors
+    * Documentation: updated User Tutorial to cover 0.9.8.x features
+    * Infrastructure: CloudFormation/SAM template and Makefile hardened for deployment
 
 0.9.8.1 Summary
 ***************


### PR DESCRIPTION
fixes #1090

Adds the ver-0.9.8.2 row to the release table and a 0.9.8.2 summary section to `docs/ReleaseHistory.rst`.