### PR TITLE
Centralize S3 object-key templates and helpers

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,3 +15,6 @@ exclude_also =
 omit =
     config.py
     config-3.py
+    # Generated copies of src/app; report coverage against the canonical source.
+    lambda-resize/src/resize_app/src/app/*
+    lambda-web/src/app/*

--- a/docs/Development/FlaskAPI.md
+++ b/docs/Development/FlaskAPI.md
@@ -345,6 +345,9 @@ video file directly to its final S3 key. The row initially has `created_at` but
 not `uploaded_at`. After S3 accepts the exact-size upload, the browser calls
 lambda-resize `POST /resize-api/v1/process-upload`; that service verifies the
 object with `HeadObject` and records `uploaded_at` and `total_bytes`. The browser
+does not construct the key: the API uses the canonical current-layout template
+`{course_id}/{movie_id}.mov` and returns the presigned POST fields needed to
+upload to it.
 then requests the first frame and links the user to Analyze.
 
 **Parameters**

--- a/docs/Development/S3.rst
+++ b/docs/Development/S3.rst
@@ -124,8 +124,9 @@ admin activity work in PR #1151.
 
 ``S3_UPLOAD_STAGING_OBJECT_KEY_TEMPLATE`` reserves the proposed
 ``uploads/{deployment_id}/{course_id}/{movie_id}.mov`` contract for that work.
-It is tested for deployment isolation but is not used by the current browser
-upload flow. Issue #1152 will decide and implement any corresponding
+Each placeholder is one S3 key component and may not contain ``/``. It is
+tested for deployment isolation but is not used by the current browser upload
+flow. Issue #1152 will decide and implement any corresponding
 ``movies/{deployment_id}/`` durable layout.
 
 Metadata Stored with Original Movies

--- a/docs/Development/S3.rst
+++ b/docs/Development/S3.rst
@@ -44,14 +44,25 @@ Current Object Layout
 The current production layout is not namespaced by stack. The live key
 templates are:
 
-* movie object: ``{course_id}/{movie_id}{ext}``
-* persisted frame: ``{course_id}/{movie_id}/{frame_number:06d}{ext}``
+* movie object: ``{course_id}/{movie_id}.mov``
+* persisted frame: ``{course_id}/{movie_id}/{frame_number:06d}.jpg``
 
 Application code must obtain object-key templates from
 ``src/app/constants.py`` rather than reconstructing paths from this
-documentation. The constants file does not yet provide separately named
-templates for every derived artifact and upload-staging location; completing
-that refactor is tracked in `GitHub issue #1153
+documentation. The canonical templates are:
+
+* ``S3_COURSE_PREFIX_TEMPLATE``
+* ``S3_MOVIE_OBJECT_KEY_TEMPLATE``
+* ``S3_TRACED_MOVIE_OBJECT_KEY_TEMPLATE``
+* ``S3_ANALYSIS_ZIP_OBJECT_KEY_TEMPLATE``
+* ``S3_FRAME_OBJECT_KEY_TEMPLATE``
+* ``S3_UPLOAD_STAGING_OBJECT_KEY_TEMPLATE``
+
+``src/app/s3_presigned.py`` provides artifact-specific formatting helpers.
+Callers use those helpers instead of calling ``str.format`` or concatenating
+prefixes and suffixes themselves. Derived-artifact helpers preserve the bucket,
+path, and extension of the original movie URN so legacy DynamoDB records remain
+readable and retraceable. This contract was centralized in `GitHub issue #1153
 <https://github.com/Plant-Tracer/webapp/issues/1153>`_.
 
 The resulting objects are:
@@ -110,6 +121,12 @@ There is no live S3 bucket-notification or EventBridge pipeline. The deprecated
 S3-triggered processing is tracked separately in `GitHub issue #1152
 <https://github.com/Plant-Tracer/webapp/issues/1152>`_; it is not part of the
 admin activity work in PR #1151.
+
+``S3_UPLOAD_STAGING_OBJECT_KEY_TEMPLATE`` reserves the proposed
+``uploads/{deployment_id}/{course_id}/{movie_id}.mov`` contract for that work.
+It is tested for deployment isolation but is not used by the current browser
+upload flow. Issue #1152 will decide and implement any corresponding
+``movies/{deployment_id}/`` durable layout.
 
 Metadata Stored with Original Movies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -202,10 +219,10 @@ Implementation Sources
 
 Use these files as the implementation sources when updating this page:
 
-* ``src/app/constants.py`` -- canonical movie and frame key templates; `GitHub
-  issue #1153 <https://github.com/Plant-Tracer/webapp/issues/1153>`_ tracks
-  adding separately named templates for every S3 artifact and staging location
-* ``src/app/s3_presigned.py`` -- S3 URNs, metadata, presigned requests, and CORS
+* ``src/app/constants.py`` -- canonical templates for every current runtime S3
+  artifact and the proposed deployment-scoped upload-staging key
+* ``src/app/s3_presigned.py`` -- artifact-specific key helpers, S3 URNs,
+  metadata, presigned requests, and CORS
 * ``src/app/odb_movie_data.py`` -- object reads, writes, deletes, and frame URNs
 * ``src/app/flask_api.py`` -- original movie upload allocation
 * ``lambda-resize/src/resize_app/movie_glue.py`` -- upload verification and

--- a/docs/Development/S3.rst
+++ b/docs/Development/S3.rst
@@ -47,6 +47,13 @@ templates are:
 * movie object: ``{course_id}/{movie_id}{ext}``
 * persisted frame: ``{course_id}/{movie_id}/{frame_number:06d}{ext}``
 
+Application code must obtain object-key templates from
+``src/app/constants.py`` rather than reconstructing paths from this
+documentation. The constants file does not yet provide separately named
+templates for every derived artifact and upload-staging location; completing
+that refactor is tracked in `GitHub issue #1153
+<https://github.com/Plant-Tracer/webapp/issues/1153>`_.
+
 The resulting objects are:
 
 .. list-table::
@@ -195,7 +202,9 @@ Implementation Sources
 
 Use these files as the implementation sources when updating this page:
 
-* ``src/app/constants.py`` -- movie and frame key templates
+* ``src/app/constants.py`` -- canonical movie and frame key templates; `GitHub
+  issue #1153 <https://github.com/Plant-Tracer/webapp/issues/1153>`_ tracks
+  adding separately named templates for every S3 artifact and staging location
 * ``src/app/s3_presigned.py`` -- S3 URNs, metadata, presigned requests, and CORS
 * ``src/app/odb_movie_data.py`` -- object reads, writes, deletes, and frame URNs
 * ``src/app/flask_api.py`` -- original movie upload allocation

--- a/docs/ReleaseHistory.rst
+++ b/docs/ReleaseHistory.rst
@@ -81,6 +81,7 @@ Unreleased Summary
       Retrace disabled until marker data changes
     * Tracing: keep markers when optical flow temporarily loses them and use
       the loaded analysis-frame height for bottom-left coordinate conversion
+    * Developer: centralize runtime S3 object-key templates and formatting helpers while preserving legacy movie URNs
     * Admin: add creation, upload, and last-movie-activity dates; FPM-based elapsed time, frame and byte sizes, resizable columns, course links, and a visible movie ``⋮`` action menu
     * Movies: distinguish created from successfully uploaded records with ``created_at`` and ``uploaded_at``, highlight pending uploads, verify exact-size direct uploads, and maintain ``last_activity_at`` through ``DDBO.update_movie()``
     * Authorization: give ``superadmin`` and ``superauditor`` cross-course movie

--- a/lambda-resize/src/resize_app/movie_glue.py
+++ b/lambda-resize/src/resize_app/movie_glue.py
@@ -356,8 +356,7 @@ def run_tracing(*, movie_id, frame_start, frame_end=None):
 
         # Upload the zipfile and the traced movie
         total_frames = int(movie_record.get(TOTAL_FRAMES) or max((tp.frame_number for tp in trackpoints)) + 1)
-        (name,ext) = os.path.splitext(movie_urn)
-        movie_zipfile_urn = name+"_zipfile"+ext
+        movie_zipfile_urn = s3_presigned.analysis_zip_urn(movie_data_urn=movie_urn)
         write_object_from_path(urn=movie_zipfile_urn, path=movie_zipfile_path)
 
         # Best-effort snapshot of the capture interval into the traced MP4. DynamoDB remains
@@ -369,7 +368,7 @@ def run_tracing(*, movie_id, frame_start, frame_end=None):
             except Exception:  # pylint: disable=broad-exception-caught
                 LOGGER.exception("failed to write fpm metadata to traced movie movie_id=%s", movie_id)
 
-        movie_traced_urn = name+"_traced"+ext
+        movie_traced_urn = s3_presigned.traced_movie_urn(movie_data_urn=movie_urn)
         write_object_from_path(urn=movie_traced_urn, path=movie_traced_path)
 
         # Update the database

--- a/src/app/constants.py
+++ b/src/app/constants.py
@@ -145,20 +145,27 @@ class C:
     DEFAULT_GET_TIMEOUT = 10
     YES = 'YES'
     NO = 'NO'
-    MOVIE_EXTENSION = ".mov"
-    MOVIE_PROCESSED_EXTENSION = '_processed.mp4'  # rotated/scaled movie written by Lambda (rotate or tracking)
-    ZIP_MOVIE_EXTENSION = '_mp4.zip'
     # Single place for analysis/shrunk frame size (zip frames and get-frame?size=analysis).
     ANALYSIS_FRAME_MAX_WIDTH = 640
     ANALYSIS_FRAME_MAX_HEIGHT = 480
-    JPEG_EXTENSION = ".jpg"
     PUT = 'put'
     GET = 'get'
     SCHEME_S3 = 's3'
     SCHEME_DB = 'db'
-    # S3 object key templates (course_id/movie_id{ext} and course_id/movie_id/frame_number{ext})
-    MOVIE_TEMPLATE = "{course_id}/{movie_id}{ext}"
-    FRAME_TEMPLATE = "{course_id}/{movie_id}/{frame_number:06d}{ext}"
+    # Runtime S3 object-key templates. Keep these synchronized with
+    # docs/Development/S3.rst. The staging template is reserved for issue #1152.
+    S3_COURSE_PREFIX_TEMPLATE = "{course_id}/"
+    S3_MOVIE_OBJECT_KEY_TEMPLATE = "{course_id}/{movie_id}.mov"
+    S3_TRACED_MOVIE_OBJECT_KEY_TEMPLATE = (
+        "{source_movie_stem}_traced{source_movie_extension}"
+    )
+    S3_ANALYSIS_ZIP_OBJECT_KEY_TEMPLATE = (
+        "{source_movie_stem}_zipfile{source_movie_extension}"
+    )
+    S3_FRAME_OBJECT_KEY_TEMPLATE = "{course_id}/{movie_id}/{frame_number:06d}.jpg"
+    S3_UPLOAD_STAGING_OBJECT_KEY_TEMPLATE = (
+        "uploads/{deployment_id}/{course_id}/{movie_id}.mov"
+    )
     SCHEME_DB_MAX_OBJECT_LEN = 16_000_000
     REDIRECT_FOUND = 302
     API_KEY_COOKIE_BASE = 'api_key'

--- a/src/app/flask_api.py
+++ b/src/app/flask_api.py
@@ -56,7 +56,7 @@ from .odb import (
     clear_movie_tracking,
 )
 from .s3_presigned import (
-    make_object_name,
+    movie_object_key,
     make_urn,
     make_signed_url,
     make_presigned_post,
@@ -811,9 +811,10 @@ def api_new_movie():
                                          fpm=fpm,
                                          upload_bytes_expected=movie_data_length)
 
-    oname = make_object_name(course_id=odb.course_id_for_movie_id(ret[MOVIE_ID]),
-                             movie_id=ret[MOVIE_ID],
-                             ext=C.MOVIE_EXTENSION)
+    oname = movie_object_key(
+        course_id=odb.course_id_for_movie_id(ret[MOVIE_ID]),
+        movie_id=ret[MOVIE_ID],
+    )
     movie_data_urn = make_urn(object_name=oname)
     odb.set_movie_data_urn(movie_id=ret[MOVIE_ID], movie_data_urn=movie_data_urn)
 

--- a/src/app/odb_movie_data.py
+++ b/src/app/odb_movie_data.py
@@ -12,7 +12,7 @@ import urllib.parse
 import requests
 from botocore.exceptions import ClientError,ParamValidationError
 
-from .s3_presigned import s3_client,make_urn,make_object_name
+from .s3_presigned import frame_object_key, make_urn, movie_object_key, s3_client
 from .constants import C,logger
 from .odb import (
     DDBO,
@@ -130,9 +130,10 @@ def set_movie_data(*,movie_id, movie_data):
     purge_movie_data(movie_id=movie_id)
     purge_movie_frames( movie_id=movie_id )
     purge_movie_zipfile( movie_id=movie_id )
-    oname = make_object_name( course_id = course_id_for_movie_id( movie_id ),
-                                        movie_id = movie_id,
-                                        ext=C.MOVIE_EXTENSION)
+    oname = movie_object_key(
+        course_id=course_id_for_movie_id(movie_id),
+        movie_id=movie_id,
+    )
     movie_data_urn        = make_urn( object_name = oname)
 
     write_object(movie_data_urn, movie_data)
@@ -211,10 +212,11 @@ def create_new_movie_frame(*, movie_id, frame_number, frame_data=None):
     course_id = course_id_for_movie_id(movie_id)
     if frame_data is not None:
         # upload the frame to the store and make a frame_urn
-        object_name = make_object_name(course_id=course_id,
-                                            movie_id=movie_id,
-                                            frame_number = frame_number,
-                                            ext=C.JPEG_EXTENSION)
+        object_name = frame_object_key(
+            course_id=course_id,
+            movie_id=movie_id,
+            frame_number=frame_number,
+        )
         frame_urn = make_urn( object_name = object_name)
         write_object(frame_urn, frame_data)
     else:

--- a/src/app/s3_presigned.py
+++ b/src/app/s3_presigned.py
@@ -76,6 +76,14 @@ def _template_value(name, value):
     return str(value)
 
 
+def _template_component(name, value):
+    """Return one required S3 key component."""
+    component = _template_value(name, value)
+    if "/" in component:
+        raise ValueError(f"{name} must be one S3 key component")
+    return component
+
+
 def course_object_prefix(*, course_id):
     """Return the current course prefix for runtime movie objects."""
     return C.S3_COURSE_PREFIX_TEMPLATE.format(
@@ -105,13 +113,10 @@ def frame_object_key(*, course_id, movie_id, frame_number):
 
 def upload_staging_object_key(*, deployment_id, course_id, movie_id):
     """Return the deployment-scoped upload key reserved for issue #1152."""
-    deployment = _template_value("deployment_id", deployment_id)
-    if "/" in deployment:
-        raise ValueError("deployment_id must be one S3 key component")
     return C.S3_UPLOAD_STAGING_OBJECT_KEY_TEMPLATE.format(
-        deployment_id=deployment,
-        course_id=_template_value("course_id", course_id),
-        movie_id=_template_value("movie_id", movie_id),
+        deployment_id=_template_component("deployment_id", deployment_id),
+        course_id=_template_component("course_id", course_id),
+        movie_id=_template_component("movie_id", movie_id),
     )
 
 

--- a/src/app/s3_presigned.py
+++ b/src/app/s3_presigned.py
@@ -12,15 +12,13 @@ import os
 import logging
 import urllib.parse
 import hashlib
+import posixpath
 
 import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from .constants import C
-
-# Prefix under which uploads land so lambda-resize is triggered; lambda moves to final key.
-UPLOAD_STAGING_PREFIX = "uploads/"
 
 logger = logging.getLogger(__name__)
 
@@ -71,23 +69,83 @@ def sha256_hash(data):
     h.update(data)
     return h.hexdigest()
 
-def make_object_name(*,course_id,movie_id,frame_number=None, ext):
-    """object_name is a URN that is generated according to a scheme
-    that uses course_id, movie_id, and frame_number. URNs are deterministic.
-    """
-    if frame_number is None:
-        return C.MOVIE_TEMPLATE.format(course_id=course_id, movie_id=movie_id, ext=ext)
-    return C.FRAME_TEMPLATE.format(course_id=course_id, movie_id=movie_id, frame_number=frame_number, ext=ext)
+def _template_value(name, value):
+    """Return one required S3 template value without changing legacy IDs."""
+    if value is None or str(value) == "":
+        raise ValueError(f"{name} is required")
+    return str(value)
 
 
-def make_urn(*, object_name, scheme = C.SCHEME_S3 ):
-    """
-    If environment variable is not set, default to the database schema
-    We grab this every time through so that the bucket can be changed during unit tests
-    """
+def course_object_prefix(*, course_id):
+    """Return the current course prefix for runtime movie objects."""
+    return C.S3_COURSE_PREFIX_TEMPLATE.format(
+        course_id=_template_value("course_id", course_id),
+    )
+
+
+def movie_object_key(*, course_id, movie_id):
+    """Return the durable original-movie object key."""
+    return C.S3_MOVIE_OBJECT_KEY_TEMPLATE.format(
+        course_id=_template_value("course_id", course_id),
+        movie_id=_template_value("movie_id", movie_id),
+    )
+
+
+def frame_object_key(*, course_id, movie_id, frame_number):
+    """Return a persisted JPEG frame object key."""
+    number = int(frame_number)
+    if number < 0:
+        raise ValueError("frame_number must be non-negative")
+    return C.S3_FRAME_OBJECT_KEY_TEMPLATE.format(
+        course_id=_template_value("course_id", course_id),
+        movie_id=_template_value("movie_id", movie_id),
+        frame_number=number,
+    )
+
+
+def upload_staging_object_key(*, deployment_id, course_id, movie_id):
+    """Return the deployment-scoped upload key reserved for issue #1152."""
+    deployment = _template_value("deployment_id", deployment_id)
+    if "/" in deployment:
+        raise ValueError("deployment_id must be one S3 key component")
+    return C.S3_UPLOAD_STAGING_OBJECT_KEY_TEMPLATE.format(
+        deployment_id=deployment,
+        course_id=_template_value("course_id", course_id),
+        movie_id=_template_value("movie_id", movie_id),
+    )
+
+
+def _derived_movie_object_key(*, source_movie_object_key, template):
+    source_stem, source_extension = posixpath.splitext(source_movie_object_key)
+    return template.format(
+        source_movie_stem=source_stem,
+        source_movie_extension=source_extension,
+    )
+
+
+def traced_movie_object_key(*, source_movie_object_key):
+    """Return the traced-movie key derived from an original movie key."""
+    return _derived_movie_object_key(
+        source_movie_object_key=source_movie_object_key,
+        template=C.S3_TRACED_MOVIE_OBJECT_KEY_TEMPLATE,
+    )
+
+
+def analysis_zip_object_key(*, source_movie_object_key):
+    """Return the analysis-frame ZIP key derived from an original movie key."""
+    return _derived_movie_object_key(
+        source_movie_object_key=source_movie_object_key,
+        template=C.S3_ANALYSIS_ZIP_OBJECT_KEY_TEMPLATE,
+    )
+
+
+def make_urn(*, object_name, scheme=C.SCHEME_S3, bucket=None):
+    """Build an S3 URN, using an explicit legacy bucket or the configured bucket."""
     if scheme not in SUPPORTED_SCHEMES:
         raise ValueError(f"Invalid scheme {scheme}")
-    netloc = os.getenv(C.PLANTTRACER_S3_BUCKET)
+    netloc = bucket or os.getenv(C.PLANTTRACER_S3_BUCKET)
+    if not netloc:
+        raise RuntimeError(f"{C.PLANTTRACER_S3_BUCKET} is not set")
     if netloc.startswith("s3:"):
         raise RuntimeError(f"{C.PLANTTRACER_S3_BUCKET} {netloc} should not start with s3://")
     ret = f"{scheme}://{netloc}/{object_name}"
@@ -103,6 +161,32 @@ def parse_s3_urn(*, urn):
     if not parsed.netloc or not parsed.path or parsed.path == "/":
         raise ValueError(f"Invalid S3 URN: {urn}")
     return parsed.netloc, parsed.path[1:]
+
+
+def traced_movie_urn(*, movie_data_urn):
+    """Return a traced-movie URN while preserving the source bucket and extension."""
+    bucket, source_key = parse_s3_urn(urn=movie_data_urn)
+    return make_urn(
+        object_name=traced_movie_object_key(source_movie_object_key=source_key),
+        bucket=bucket,
+    )
+
+
+def analysis_zip_urn(*, movie_data_urn):
+    """Return an analysis-frame ZIP URN while preserving the source bucket and extension."""
+    bucket, source_key = parse_s3_urn(urn=movie_data_urn)
+    return make_urn(
+        object_name=analysis_zip_object_key(source_movie_object_key=source_key),
+        bucket=bucket,
+    )
+
+
+def replace_course_object_key(*, object_key, from_course_id, to_course_id):
+    """Move one current-layout key between course prefixes."""
+    source_prefix = course_object_prefix(course_id=from_course_id)
+    if not object_key.startswith(source_prefix):
+        raise ValueError(f"S3 key {object_key} does not start with {source_prefix}")
+    return course_object_prefix(course_id=to_course_id) + object_key[len(source_prefix):]
 
 
 def make_signed_url(*, urn, operation=C.GET, expires=3600, download_name=None):

--- a/src/dbbackup.py
+++ b/src/dbbackup.py
@@ -68,7 +68,7 @@ from app.odb import (
     USERS,
     USER_NAME,
 )
-from app.s3_presigned import parse_s3_urn, s3_client
+from app.s3_presigned import make_urn, parse_s3_urn, replace_course_object_key, s3_client
 
 
 FORMAT_VERSION = 1
@@ -1250,7 +1250,10 @@ def rewrite_movie_rows_for_target_bucket(
         movie_object = object_by_movie_id.get(row[MOVIE_ID])
         if movie_object is not None and new_row.get(MOVIE_DATA_URN):
             bucket = restore_bucket_for_movie_object(movie_object, bucket_plan)
-            new_row[MOVIE_DATA_URN] = f"s3://{bucket}/{movie_object.key}"
+            new_row[MOVIE_DATA_URN] = make_urn(
+                object_name=movie_object.key,
+                bucket=bucket,
+            )
         rewritten.append(new_row)
     return rewritten
 
@@ -1560,15 +1563,19 @@ def command_send_restore_links(args) -> int:
 
 def migrate_s3_urn(urn: str, *, from_course_id: str, to_course_id: str, commit: bool) -> str:
     bucket, key = parse_s3_urn(urn=urn)
-    source_prefix = f"{from_course_id}/"
-    if not key.startswith(source_prefix):
-        raise DbBackupError(f"S3 key {key} does not start with {source_prefix}")
-    new_key = f"{to_course_id}/{key[len(source_prefix):]}"
+    try:
+        new_key = replace_course_object_key(
+            object_key=key,
+            from_course_id=from_course_id,
+            to_course_id=to_course_id,
+        )
+    except ValueError as exc:
+        raise DbBackupError(str(exc)) from exc
     if commit and new_key != key:
         body = s3_client().get_object(Bucket=bucket, Key=key)["Body"].read()
         s3_client().put_object(Bucket=bucket, Key=new_key, Body=body)
         s3_client().delete_object(Bucket=bucket, Key=key)
-    return f"s3://{bucket}/{new_key}"
+    return make_urn(object_name=new_key, bucket=bucket)
 
 
 def migrate_movie_frames(

--- a/tests/db_object_test.py
+++ b/tests/db_object_test.py
@@ -70,12 +70,19 @@ def test_object_key_components_cannot_escape_their_prefix():
         with pytest.raises(ValueError, match=name):
             build_key()
 
-    with pytest.raises(ValueError, match="deployment_id"):
-        s3_presigned.upload_staging_object_key(
-            deployment_id="prod/other",
-            course_id="c1",
-            movie_id="m2",
-        )
+    for name, kwargs in (
+        ("deployment_id", {"deployment_id": "prod/other"}),
+        ("course_id", {"course_id": "course/other"}),
+        ("movie_id", {"movie_id": "movie/other"}),
+    ):
+        values = {
+            "deployment_id": "prod",
+            "course_id": "c1",
+            "movie_id": "m2",
+        }
+        values.update(kwargs)
+        with pytest.raises(ValueError, match=name):
+            s3_presigned.upload_staging_object_key(**values)
     with pytest.raises(ValueError, match="non-negative"):
         s3_presigned.frame_object_key(
             course_id="c1",

--- a/tests/db_object_test.py
+++ b/tests/db_object_test.py
@@ -116,6 +116,13 @@ def test_make_urn_rejects_missing_or_malformed_bucket(monkeypatch):
         )
 
 
+def test_parse_s3_urn_rejects_non_s3_and_incomplete_urns():
+    with pytest.raises(RuntimeError, match="Unknown scheme"):
+        s3_presigned.parse_s3_urn(urn="https://movies/course/movie.mov")
+    with pytest.raises(ValueError, match="Invalid S3 URN"):
+        s3_presigned.parse_s3_urn(urn="s3://movies")
+
+
 def test_derived_movie_urns_preserve_legacy_bucket_path_and_extension():
     legacy_urn = "s3://legacy-bucket/archive/c1/m2.mp4"
 
@@ -163,3 +170,18 @@ def test_legacy_movie_urn_remains_readable(local_s3):
         assert odb_movie_data.read_object(urn=legacy_urn) == movie_data
     finally:
         odb_movie_data.delete_object(urn=legacy_urn)
+
+
+def test_create_movie_frame_persists_namespaced_bytes(new_movie):
+    movie_id = new_movie[odb.MOVIE_ID]
+    frame_data = b"jpeg frame bytes"
+
+    frame_urn = odb_movie_data.create_new_movie_frame(
+        movie_id=movie_id,
+        frame_number=7,
+        frame_data=frame_data,
+    )
+
+    assert frame_urn.endswith(f"/{new_movie[odb.COURSE_ID]}/{movie_id}/000007.jpg")
+    assert odb_movie_data.read_object(urn=frame_urn) == frame_data
+    assert odb.DDBO().get_movie_frame(movie_id, 7)[odb.FRAME_URN] == frame_urn

--- a/tests/db_object_test.py
+++ b/tests/db_object_test.py
@@ -55,6 +55,21 @@ def test_upload_staging_keys_are_isolated_by_deployment():
 
 
 def test_object_key_components_cannot_escape_their_prefix():
+    for name, build_key in (
+        ("course_id", lambda: s3_presigned.movie_object_key(course_id="", movie_id="m2")),
+        ("movie_id", lambda: s3_presigned.movie_object_key(course_id="c1", movie_id=None)),
+        (
+            "deployment_id",
+            lambda: s3_presigned.upload_staging_object_key(
+                deployment_id="",
+                course_id="c1",
+                movie_id="m2",
+            ),
+        ),
+    ):
+        with pytest.raises(ValueError, match=name):
+            build_key()
+
     with pytest.raises(ValueError, match="deployment_id"):
         s3_presigned.upload_staging_object_key(
             deployment_id="prod/other",
@@ -66,6 +81,38 @@ def test_object_key_components_cannot_escape_their_prefix():
             course_id="c1",
             movie_id="m2",
             frame_number=-1,
+        )
+
+
+def test_course_object_keys_can_be_reassigned_without_changing_the_suffix():
+    assert s3_presigned.replace_course_object_key(
+        object_key="course-1/movie-2/000003.jpg",
+        from_course_id="course-1",
+        to_course_id="course-3",
+    ) == "course-3/movie-2/000003.jpg"
+
+    with pytest.raises(ValueError, match="does not start"):
+        s3_presigned.replace_course_object_key(
+            object_key="course-10/movie-2.mov",
+            from_course_id="course-1",
+            to_course_id="course-3",
+        )
+
+
+def test_make_urn_rejects_missing_or_malformed_bucket(monkeypatch):
+    monkeypatch.delenv("PLANTTRACER_S3_BUCKET", raising=False)
+    with pytest.raises(RuntimeError, match="is not set"):
+        s3_presigned.make_urn(object_name="course-1/movie-2.mov")
+    with pytest.raises(RuntimeError, match="should not start"):
+        s3_presigned.make_urn(
+            object_name="course-1/movie-2.mov",
+            bucket="s3://movies",
+        )
+    with pytest.raises(ValueError, match="Invalid scheme"):
+        s3_presigned.make_urn(
+            object_name="course-1/movie-2.mov",
+            bucket="movies",
+            scheme="https",
         )
 
 

--- a/tests/db_object_test.py
+++ b/tests/db_object_test.py
@@ -5,6 +5,7 @@ import uuid
 import hashlib
 
 import boto3
+import pytest
 
 from app import s3_presigned
 from app import odb_movie_data
@@ -15,14 +16,73 @@ from app.constants import logger
 
 s3client = boto3.client('s3')
 
-def test_object_name():
-    assert s3_presigned.make_object_name(course_id=1, movie_id=2, ext='.mov').endswith(".mov")
-    assert s3_presigned.make_object_name(course_id=1, movie_id=2, frame_number=3, ext='.jpeg').endswith(".jpeg")
+def test_runtime_s3_object_keys_are_deterministic():
+    movie_key = s3_presigned.movie_object_key(course_id="c1", movie_id="m2")
+
+    assert movie_key == "c1/m2.mov"
+    assert s3_presigned.traced_movie_object_key(
+        source_movie_object_key=movie_key,
+    ) == "c1/m2_traced.mov"
+    assert s3_presigned.analysis_zip_object_key(
+        source_movie_object_key=movie_key,
+    ) == "c1/m2_zipfile.mov"
+    assert s3_presigned.frame_object_key(
+        course_id="c1",
+        movie_id="m2",
+        frame_number=3,
+    ) == "c1/m2/000003.jpg"
+    assert s3_presigned.movie_object_key(
+        course_id="legacy/course",
+        movie_id="m2",
+    ) == "legacy/course/m2.mov"
+
+
+def test_upload_staging_keys_are_isolated_by_deployment():
+    prod_key = s3_presigned.upload_staging_object_key(
+        deployment_id="prod",
+        course_id="c1",
+        movie_id="m2",
+    )
+    demo_key = s3_presigned.upload_staging_object_key(
+        deployment_id="demo",
+        course_id="c1",
+        movie_id="m2",
+    )
+
+    assert prod_key == "uploads/prod/c1/m2.mov"
+    assert demo_key == "uploads/demo/c1/m2.mov"
+    assert prod_key != demo_key
+
+
+def test_object_key_components_cannot_escape_their_prefix():
+    with pytest.raises(ValueError, match="deployment_id"):
+        s3_presigned.upload_staging_object_key(
+            deployment_id="prod/other",
+            course_id="c1",
+            movie_id="m2",
+        )
+    with pytest.raises(ValueError, match="non-negative"):
+        s3_presigned.frame_object_key(
+            course_id="c1",
+            movie_id="m2",
+            frame_number=-1,
+        )
+
+
+def test_derived_movie_urns_preserve_legacy_bucket_path_and_extension():
+    legacy_urn = "s3://legacy-bucket/archive/c1/m2.mp4"
+
+    assert s3_presigned.traced_movie_urn(
+        movie_data_urn=legacy_urn,
+    ) == "s3://legacy-bucket/archive/c1/m2_traced.mp4"
+    assert s3_presigned.analysis_zip_urn(
+        movie_data_urn=legacy_urn,
+    ) == "s3://legacy-bucket/archive/c1/m2_zipfile.mp4"
 
 def test_make_urn(local_s3):
-    name = s3_presigned.make_object_name(course_id=1, movie_id=2, ext='.txt')
+    name = s3_presigned.movie_object_key(course_id="c1", movie_id="m2")
     a = s3_presigned.make_urn(object_name=name)
-    assert a.endswith(".txt")
+    assert a.endswith("/c1/m2.mov")
 
 def test_write_read_delete_object(local_s3):
     DATA = str(uuid.uuid4()).encode('utf-8')
@@ -32,7 +92,7 @@ def test_write_read_delete_object(local_s3):
 
     course_id = 'bogus'
     movie_id = odb.new_movie_id()
-    name = s3_presigned.make_object_name(course_id=course_id, movie_id=movie_id, ext='.txt')
+    name = s3_presigned.movie_object_key(course_id=course_id, movie_id=movie_id)
     urn  = s3_presigned.make_urn(object_name=name)
     try:
         odb_movie_data.write_object(urn=urn, object_data=DATA)
@@ -45,3 +105,14 @@ def test_write_read_delete_object(local_s3):
 
     odb_movie_data.delete_object(urn=urn)
     assert odb_movie_data.read_object(urn=urn) is None
+
+
+def test_legacy_movie_urn_remains_readable(local_s3):
+    legacy_urn = s3_presigned.make_urn(object_name="legacy/c1/m2.mp4")
+    movie_data = b"legacy movie bytes"
+
+    odb_movie_data.write_object(urn=legacy_urn, object_data=movie_data)
+    try:
+        assert odb_movie_data.read_object(urn=legacy_urn) == movie_data
+    finally:
+        odb_movie_data.delete_object(urn=legacy_urn)

--- a/tests/dbbackup_test.py
+++ b/tests/dbbackup_test.py
@@ -959,3 +959,13 @@ def test_migrate_course_preflight_and_commit(prefix_tools, backup_scenario: Back
     } not in enrollments
     migrated_key = f"{backup_scenario.migration_course_id}/{backup_scenario.active_movie_id}.mov"
     assert s3_object_bytes(backup_scenario.bucket, migrated_key) == backup_scenario.active_movie_bytes
+
+
+def test_migrate_s3_urn_rejects_an_unrelated_course_prefix():
+    with pytest.raises(dbbackup.DbBackupError, match="does not start"):
+        dbbackup.migrate_s3_urn(
+            "s3://movies/course-10/movie.mov",
+            from_course_id="course-1",
+            to_course_id="course-2",
+            commit=False,
+        )


### PR DESCRIPTION
## Summary

- define separately named Python string templates in `src/app/constants.py` for the current course prefix, original movie, traced movie, analysis ZIP, persisted frame, and the deployment-scoped upload-staging key reserved for #1152
- add artifact-specific formatting helpers in `s3_presigned.py` and remove generic/ad hoc key construction from Flask uploads, movie/frame storage, resize processing, restore, and course migration
- preserve the source bucket, path, and extension when deriving traced and ZIP URNs so legacy DynamoDB records remain readable and retraceable
- document the canonical constants and helpers in `S3.rst` and the unreleased history

## Compatibility and scope

This PR does not change the current production object layout, migrate stored objects, or activate S3/EventBridge triggering. The existing `_zipfile.mov` key remains unchanged. `S3_UPLOAD_STAGING_OBJECT_KEY_TEMPLATE` defines and tests `uploads/{deployment_id}/{course_id}/{movie_id}.mov`, but Issue #1152 remains responsible for using it and deciding the future `movies/{deployment_id}/` durable layout.

No DynamoDB schema or data migration is required.

## Validation

- `make pylint` — 10.00/10
- `make lambda-resize-check` — 24 passed
- `make lambda-web-check` — 2 passed
- `make pytest1 TEST1MODULE=tests/db_object_test.py` — 7 passed against MinIO
- `make pytest1 TEST1MODULE=tests/dbbackup_test.py` — 13 passed against MinIO and DynamoDB Local
- `make pytest1 TEST1MODULE='tests/movie_test.py tests/endpoint_test.py'` — 29 passed
- strict Sphinx build with `-W --keep-going` — passed
- broad `make pytest` run reached 261 passed and 6 browser skips; it was stopped before completion to avoid further Chrome/browser execution
- `git diff --check origin/main...HEAD`

fixes #1153
refs #1152
