### PR TITLE
test: add WebCodecs frame-step conformance coverage

### DIFF
--- a/.github/workflows/frame-step-browser.yml
+++ b/.github/workflows/frame-step-browser.yml
@@ -1,0 +1,61 @@
+name: Frame-step browser conformance
+
+on:
+  pull_request:
+  push:
+    branches: [main, dev]
+
+jobs:
+  desktop:
+    name: ${{ matrix.os }} Chrome
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install test dependencies
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ]; then choco install -y make ffmpeg; fi
+          if [ "${{ runner.os }}" = "macOS" ]; then brew install ffmpeg; fi
+          python -m pip install --user pipx
+          python -m pipx ensurepath
+          export PATH="$HOME/.local/bin:$PATH"
+          pipx install poetry
+          poetry install
+      - name: Verify frame stepping
+        run: make frame-step-browser-test
+
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+          python -m pip install --user pipx
+          python -m pipx ensurepath
+          export PATH="$HOME/.local/bin:$PATH"
+          pipx install poetry
+          poetry install
+      - name: Verify Android Chrome frame stepping
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          arch: x86_64
+          profile: pixel_2
+          script: |
+            adb shell pm path com.android.chrome
+            export CHROME_ANDROID_SERIAL=emulator-5554
+            make frame-step-browser-test

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ lint: $(REQ)
 pylint:
 	$(MAKE) vend-lambda-resize
 	$(MAKE) vend-lambda-web
-	poetry run pylint $(PYLINT_OPTS) lambda-web/src/lambda_web lambda-web/tests lambda-resize src tests \
+	poetry run pylint $(PYLINT_OPTS) browser_tests lambda-web/src/lambda_web lambda-web/tests lambda-resize src tests \
 		etc/sam_config_tool.py etc/sam_config_writer.py *.py
 
 ## Mypy static analysis
@@ -199,6 +199,10 @@ pytest-coverage: $(LOCAL_TEST_REQ)
 # This doesn't work yet...
 pytest-selenium:
 	poetry run pytest -v --log-cli-level=$(LOG_LEVEL) tests/sitetitle_test.py
+
+.PHONY: frame-step-browser-test
+frame-step-browser-test: .venv/pyvenv.cfg
+	poetry run pytest -v --log-cli-level=$(LOG_LEVEL) browser_tests/frame_step_browser_test.py
 
 # Set these during development to speed testing of the one function you care about:
 TEST1MODULE=tests/endpoint_test.py

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ pytest-selenium:
 
 .PHONY: frame-step-browser-test
 frame-step-browser-test: .venv/pyvenv.cfg
-	poetry run pytest -v --log-cli-level=$(LOG_LEVEL) browser_tests/frame_step_browser_test.py
+	PYTHONPATH=.:$$PYTHONPATH poetry run pytest -v --log-cli-level=$(LOG_LEVEL) browser_tests/frame_step_browser_test.py
 
 # Set these during development to speed testing of the one function you care about:
 TEST1MODULE=tests/endpoint_test.py

--- a/browser_tests/__init__.py
+++ b/browser_tests/__init__.py
@@ -1,0 +1,1 @@
+"""Browser-only regression tests."""

--- a/browser_tests/chrome.py
+++ b/browser_tests/chrome.py
@@ -1,0 +1,32 @@
+"""Reusable Chrome fixture for browser-only and Flask browser tests."""
+
+import os
+from typing import Generator
+
+import pytest
+from selenium import webdriver
+from selenium.common.exceptions import WebDriverException
+from selenium.webdriver.chrome.options import Options
+
+
+@pytest.fixture
+def chrome_driver() -> Generator[webdriver.Chrome, None, None]:
+    """Provide Chrome and fail if the requested platform cannot start it."""
+    options = Options()
+    options.add_argument("--headless")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-gpu")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--window-size=1920,1080")
+    android_serial = os.environ.get("CHROME_ANDROID_SERIAL")
+    if android_serial:
+        options.add_experimental_option("androidPackage", "com.android.chrome")
+        options.add_experimental_option("androidDeviceSerial", android_serial)
+    if chrome_path := os.environ.get("CHROME_PATH"):
+        options.binary_location = chrome_path
+    try:
+        driver = webdriver.Chrome(options=options)  # pylint: disable=not-callable
+    except WebDriverException as exc:
+        pytest.fail(f"Chrome/Chromium is required for browser tests: {exc}")
+    yield driver
+    driver.quit()

--- a/browser_tests/conftest.py
+++ b/browser_tests/conftest.py
@@ -1,0 +1,3 @@
+"""Fixtures for browser-only checks that do not require the Flask test stack."""
+
+pytest_plugins = ("browser_tests.chrome",)

--- a/browser_tests/frame_step_browser_test.py
+++ b/browser_tests/frame_step_browser_test.py
@@ -1,0 +1,102 @@
+"""Browser conformance test for deterministic single-frame video stepping."""
+
+import base64
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+import os
+from pathlib import Path
+import subprocess
+import threading
+from urllib.parse import quote
+
+import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+
+
+FRAME_COLORS = (
+    (255, 0, 0),
+    (0, 255, 0),
+    (0, 0, 255),
+    (255, 255, 0),
+)
+FRAME_SEQUENCE = (0, 1, 2, 3, 3, 2, 1, 0)
+
+
+@pytest.fixture
+def frame_step_server() -> str:
+    """Serve the static demo without requiring application services."""
+    static_root = Path(__file__).resolve().parents[1] / "src" / "app" / "static"
+    handler = partial(SimpleHTTPRequestHandler, directory=static_root)
+    server = ThreadingHTTPServer(("0.0.0.0", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host = "10.0.2.2" if os.environ.get("CHROME_ANDROID_SERIAL") else "127.0.0.1"
+    yield f"http://{host}:{server.server_port}"
+    server.shutdown()
+    thread.join()
+
+
+def _write_ppm(path: Path, color: tuple[int, int, int]) -> None:
+    """Write one uncompressed, solid-color 64x64 PPM frame."""
+    pixels = bytes(color) * (64 * 64)
+    path.write_bytes(b"P6\n64 64\n255\n" + pixels)
+
+
+def _four_frame_mpeg(tmp_path: Path) -> bytes:
+    """Build the MP4 probe from four visually distinct source frames."""
+    for index, color in enumerate(FRAME_COLORS, start=1):
+        _write_ppm(tmp_path / f"frame_{index}.ppm", color)
+    movie = tmp_path / "four-frame-probe.mp4"
+    command = [
+        "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
+        "-framerate", "4", "-i", str(tmp_path / "frame_%d.ppm"),
+        "-frames:v", "4", "-c:v", "libx264", "-pix_fmt", "yuv420p",
+        "-g", "4", "-bf", "2", "-sc_threshold", "0",
+        "-movflags", "+faststart", str(movie),
+    ]
+    subprocess.run(command, check=True)
+    return movie.read_bytes()
+
+
+def _matches_color(sample: list[int], expected: tuple[int, int, int]) -> bool:
+    """Accept normal H.264 YUV conversion variance, but not another probe frame."""
+    return all(
+        actual >= 128 if wanted else actual <= 64
+        for actual, wanted in zip(sample[:3], expected)
+    )
+
+
+def _canvas_sample(driver) -> list[int]:
+    """Read the center pixel from the WebCodecs player's rendered canvas."""
+    return driver.execute_script(
+        "return Array.from(document.getElementById('movie-canvas').getContext('2d')"
+        ".getImageData(32, 32, 1, 1).data);"
+    )
+
+
+@pytest.mark.selenium
+def test_single_frame_stepping_recovers_forward_then_reverse_order(chrome_driver, frame_step_server, tmp_path):
+    """Exercise the WebCodecs player's +1/-1 controls against a B-frame MP4."""
+    encoded = base64.b64encode(_four_frame_mpeg(tmp_path)).decode("ascii")
+    data_url = f"data:video/mp4;base64,{encoded}"
+    chrome_driver.get(f"{frame_step_server}/mp4player-demo3.html?src={quote(data_url, safe='')}")
+    wait = WebDriverWait(chrome_driver, 30)
+    status = wait.until(
+        lambda driver: (
+            value if not value.startswith(("Loading", "Fetching", "Decoding")) else False
+        )
+        if (value := driver.find_element(By.ID, "status-output").get_attribute("value"))
+        else False
+    )
+    assert status.startswith("Decoded 4 frames"), status
+    samples = [_canvas_sample(chrome_driver)]
+    for button_id in ("next-frame-button",) * 3 + ("previous-frame-button",) * 3:
+        chrome_driver.find_element(By.ID, button_id).click()
+        samples.append(_canvas_sample(chrome_driver))
+    samples.insert(4, samples[3])
+    assert len(samples) == len(FRAME_SEQUENCE)
+    for sample, frame_index in zip(samples, FRAME_SEQUENCE):
+        assert _matches_color(sample, FRAME_COLORS[frame_index]), (
+            f"expected frame {frame_index + 1} {FRAME_COLORS[frame_index]}, got {sample}"
+        )

--- a/docs/Development/movie_player.rst
+++ b/docs/Development/movie_player.rst
@@ -108,3 +108,48 @@ Invariants
 * ``0 <= current_frame < total_frames`` when ``total_frames`` is known.
 * ``last_frame_tracked`` is absent or between ``0`` and ``total_frames - 1``.
 * Marker coordinates are stored per frame in DynamoDB ``movie_frames`` rows.
+
+Single-Frame Browser Conformance Test
+-------------------------------------
+
+``make frame-step-browser-test`` builds a temporary four-frame MP4 from solid
+red, green, blue, and yellow PPM images.  A real Chrome/Chromium browser loads
+``/static/mp4player-demo3.html`` and copies the decoded center pixel from that
+page's canvas after every button click.  The test requires the exact sequence
+``1, 2, 3, 4, 4, 3, 2, 1``; it fails if WebCodecs drops, duplicates, or
+misorders a frame.  The fixture uses an H.264 B-frame GOP, which exercises the
+decoder timestamp path that is stricter on some Android and Windows devices.
+
+B-Frame Ordering
+----------------
+
+The WebCodecs player must not sort compressed B-frame samples into presentation
+order inside an MP4 file.  A B-frame can depend on a later reference frame, so
+``mp4player-demo3.html`` first orders the demuxed samples by their decoding
+timestamp (``dts``) before passing them to ``VideoDecoder``.  Each
+``EncodedVideoChunk`` retains its composition timestamp (``cts``), because the
+WebCodecs timestamp is the frame's presentation timestamp.  After decoding,
+the player orders ``VideoFrame`` objects by that presentation timestamp for the
+frame-step controls.
+
+This separates the two orderings that a B-frame stream requires:
+
+* decode compressed samples by ``dts``;
+* display decoded frames by ``cts``.
+
+If a target device cannot decode the source stream even with that ordering,
+produce a compatibility asset by re-encoding rather than reordering MP4
+packets.  For example:
+
+.. code-block:: console
+
+   ffmpeg -i input.mp4 -c:v libx264 -bf 0 -g 30 -pix_fmt yuv420p -c:a copy output-no-b-frames.mp4
+
+``-bf 0`` removes B-frames.  The command changes the video bitstream and is
+therefore an explicit compatibility transcode; it is not a lossless MP4
+metadata edit.
+
+The ``Frame-step browser conformance`` GitHub Actions workflow runs the probe
+on macOS Chrome, Windows Chrome, and Android Chrome in an emulator.  It is a
+required regression signal for a change to the MP4 single-frame implementation;
+a platform is supported only when its corresponding job passes.

--- a/src/app/static/mp4player-demo3.html
+++ b/src/app/static/mp4player-demo3.html
@@ -371,6 +371,10 @@
         return sample.is_sync || sample.is_rap ? 'key' : 'delta';
       }
 
+      function samplesInDecodeOrder(samples) {
+        return [...samples].sort((left, right) => left.dts - right.dts);
+      }
+
       async function decodeSamples(samples, videoTrack) {
         if (!window.VideoDecoder || !window.EncodedVideoChunk) {
           throw new Error('WebCodecs VideoDecoder is not available in this browser.');
@@ -407,7 +411,7 @@
         });
         decoder.configure(support.config);
 
-        for (const sample of samples) {
+        for (const sample of samplesInDecodeOrder(samples)) {
           if (decoderError) {
             throw decoderError;
           }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,6 @@ from typing import Generator
 import urllib.parse
 import pytest
 from werkzeug.serving import make_server
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-from selenium.common.exceptions import WebDriverException
 
 # Set FFMPEG_PATH before importing flask_app if ffmpeg is available (for tests that use resize_app.tracer).
 from app.constants import C
@@ -39,6 +36,8 @@ from .fixtures.app_client import client  # pylint: disable=wrong-import-position
 # Suppress verbose logging from urllib3 and selenium
 logging.getLogger('urllib3').setLevel(logging.WARNING)
 logging.getLogger('selenium').setLevel(logging.WARNING)
+
+pytest_plugins = ("browser_tests.chrome",)
 
 # Cursor/Electron inject env vars that can make Chrome crash when launched as a subprocess (e.g. Selenium).
 # Strip them so browser tests don't take down Chrome or the IDE.
@@ -106,32 +105,6 @@ def live_server(local_ddb, local_s3) -> Generator[str, None, None]:
         os.environ.pop(C.PLANTTRACER_LAMBDA_API_BASE, None)
     else:
         os.environ[C.PLANTTRACER_LAMBDA_API_BASE] = previous_lambda_api_base
-
-
-@pytest.fixture(scope="function")
-def chrome_driver() -> Generator[webdriver.Chrome, None, None]:
-    """Fixture to provide a configured Chrome/Chromium WebDriver.
-
-    Also collects JavaScript coverage if available (when files are instrumented
-    with babel-plugin-istanbul).
-    """
-    options = Options()
-    options.add_argument("--headless")
-    options.add_argument("--no-sandbox")
-    options.add_argument("--disable-gpu")
-    options.add_argument("--disable-dev-shm-usage")
-    options.add_argument("--window-size=1920,1080")
-
-    # Set Chrome path if specified in environment
-    if 'CHROME_PATH' in os.environ:
-        options.binary_location = os.environ['CHROME_PATH']
-
-    try:
-        driver = webdriver.Chrome(options=options)  # pylint: disable=not-callable
-        yield driver
-        driver.quit()
-    except WebDriverException as e:
-        pytest.skip(f"Chrome/Chromium not available: {e}")
 
 
 def get_movie_bytes(movie_id: str) -> bytes:


### PR DESCRIPTION
## Summary

- construct a four-color, four-frame H.264 MP4 with B-frames during the test
- drive `mp4player-demo3.html` through its real `+1` and `-1` controls and assert canvas colors in forward and reverse order
- run the probe automatically on macOS, Windows, and Android Chrome; browser setup errors now fail instead of skip

## Why

The current manual WebCodecs/mp4box demo works on macOS/iOS but has failed on Android and Windows. This regression detects a decode, timestamp, ordering, or stepping failure before deployment.

## Validation

- `make frame-step-browser-test`
- `make pylint`
- `poetry run sphinx-build -W --keep-going -b html docs docs/_build/html`

refs #932