### PR TITLE
Fix HTTP 500 caused by an invalid api_key

### DIFF
--- a/src/app/flask_app.py
+++ b/src/app/flask_app.py
@@ -7,7 +7,6 @@ Main Flask application for planttracer.
 import sys
 import os
 import time
-import traceback
 import logging
 
 from flask import Flask, request, render_template, jsonify, make_response, Response, redirect
@@ -260,12 +259,9 @@ def func_config_error():
 ## These mostly do forms or static content
 
 @app.route('/', methods=GET)
-def func_root() -> str | tuple[str, int]:
+def func_root() -> str:
     """/ - serve the home page"""
-    try:
-        return render_template('index.html', **page_dict())
-    except Exception as ex:     # pylint: disable=broad-exception-caught
-        return f"<h1>500 Exception:</h1><pre>\n{ex}\n{traceback.print_exception(ex)}</pre>", 500
+    return render_template('index.html', **page_dict())
 
 
 @app.route('/about', methods=GET)

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -24,6 +24,17 @@ def test_version(client):  # Use the app fixture
     assert os.environ[C.DYNAMODB_TABLE_PREFIX] in response.text
 
 
+def test_root_clears_invalid_api_key_cookie(client):
+    """An invalid browser cookie must use the normal logout redirect, not a 500."""
+    client.set_cookie(apikey.cookie_name(), "not-a-valid-api-key")
+
+    response = client.get("/")
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/logout")
+    assert f"{apikey.cookie_name()}=" in response.headers["Set-Cookie"]
+
+
 # These check type conversion
 
 def test_get_float(mocker):


### PR DESCRIPTION
fixes #1135

An invalid `api_key` cookie on `/` was caught by the route-local broad exception handler and rendered as HTTP 500. Let Flask route `InvalidAPI_Key` to its existing error handler, which clears the invalid cookie and redirects to `/logout`.

Validation:
- `PYTEST_ADDOPTS='-k test_root_clears_invalid_api_key_cookie -x' make pytest`
- `make pylint` (10.00/10)

No browser tests run (not needed for this server-side cookie-handling regression).